### PR TITLE
Refactor masker builders to streamline method chaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,7 @@ var masker = Masker.json()
     .withProperty("email") // Default fixed pattern masking
     .withProperty("phone", Masker.base64())
     .withProperty("creditCard", Masker.creditCard('X'))    
-    .withProperty("name", Masker.delegate(value -> "MASKED"))    
-    .build();
+    .withProperty("name", Masker.delegate(value -> "MASKED"));
 
 // Apply masking
 var maskedJson = masker.apply(json);
@@ -140,8 +139,7 @@ String logContent = """
 
 // Create a MultilinePatternMasker instance
 var masker = Masker.multilinePattern()
-    .withMaskPattern("(\\d+\\.\\d+\\.\\d+\\.\\d+)")
-    .build();
+    .withMaskPattern("(\\d+\\.\\d+\\.\\d+\\.\\d+)");
 
 // Apply masking
 var maskedContent = masker.apply(logContent);

--- a/src/main/java/io/github/ehayik/jmaskify/JsonMasker.java
+++ b/src/main/java/io/github/ehayik/jmaskify/JsonMasker.java
@@ -17,6 +17,7 @@ import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -290,6 +291,44 @@ public final class JsonMasker implements Masker<String> {
         public Builder prettify(boolean prettify) {
             this.prettify = prettify;
             return this;
+        }
+
+        /**
+         * Constructs a new {@link JsonMasker} instance and applies transformations to the given JSON string,
+         * such as masking specific fields.
+         *
+         * @param content the JSON string to be transformed, can be {@code null}
+         * @return the transformed JSON string, or {@code null} if the input string was {@code null}
+         * @see JsonMasker#apply(String)
+         */
+        @Nullable
+        public String apply(@Nullable String content) {
+            return build().apply(content);
+        }
+
+        /**
+         * Constructs a new {@link JsonMasker} instance
+         * and serializes the given object to a JSON string applying masking to specific fields.
+         *
+         * @param value the object to be masked, which will be converted to a JSON string
+         * @return the masked JSON string, or {@code null} if the input object is {@code null}
+         * @see JsonMasker#applyToObject(Object)
+         */
+        @Nullable
+        public String applyToObject(@Nullable Object value) {
+            return build().applyToObject(value);
+        }
+
+        /**
+         * Returns a composed {@link Function} that first applies the current masking operation and then
+         * applies the given {@code Masker<String>} operation.
+         *
+         * @param after the {@code Masker<String>} operation to apply after the current masking operation
+         * @return a composed {@code Function<String, String>} that applies the current operation followed by the given one
+         * @throws NullPointerException if {@code after} is {@code null}
+         */
+        public Function<String, String> andThen(Masker<String> after) {
+            return build().andThen(after);
         }
 
         /**

--- a/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
+++ b/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
@@ -5,6 +5,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import jakarta.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
@@ -61,7 +62,7 @@ public final class MultilinePatternMasker implements Masker<String> {
      * <p>
      *      Each match found by the patterns is replaced with a specified substitution character.
      *
-     * @param text the input string to be processed; may be {@code null}
+     * @param text the input string to be processed, may be {@code null}
      * @return the processed string with substitutions, or {@code null} if the input text was {@code null}
      */
     @Nullable
@@ -131,6 +132,37 @@ public final class MultilinePatternMasker implements Masker<String> {
         public Builder withSubstitution(char substitution) {
             this.substitution = substitution;
             return this;
+        }
+
+        /**
+         * Constructs a new {@link MultilinePatternMasker} instance
+         * and applies the specified multiline pattern to the given text.
+         *
+         * <p>
+         *      Each match found by the patterns is replaced with a specified substitution character.
+         *
+         * @param text the input string to be processed, may be {@code null}
+         * @return the processed string with substitutions, or {@code null} if the input text was {@code null}
+         * @throws MaskingException if no patterns were added to the builder
+         *  @implNote All the specified mask patterns will be combined into a single pattern
+         *            using the {@link Pattern#MULTILINE} flag.
+         * @see MultilinePatternMasker#apply(String)
+         */
+        @Nullable
+        public String apply(@Nullable String text) {
+            return build().apply(text);
+        }
+
+        /**
+         * Returns a composed {@link Function} that first applies the current masking operation and then
+         * applies the given {@code Masker<String>} operation.
+         *
+         * @param after the {@code Masker<String>} operation to apply after the current masking operation
+         * @return a composed {@code Function<String, String>} that applies the current operation followed by the given one
+         * @throws NullPointerException if {@code after} is {@code null}
+         */
+        public Function<String, String> andThen(Masker<String> after) {
+            return build().andThen(after);
         }
 
         /**

--- a/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
+++ b/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
@@ -143,9 +143,6 @@ public final class MultilinePatternMasker implements Masker<String> {
          *
          * @param text the input string to be processed, may be {@code null}
          * @return the processed string with substitutions, or {@code null} if the input text was {@code null}
-         * @throws MaskingException if no patterns were added to the builder
-         *  @implNote All the specified mask patterns will be combined into a single pattern
-         *            using the {@link Pattern#MULTILINE} flag.
          * @see MultilinePatternMasker#apply(String)
          */
         @Nullable

--- a/src/test/java/io/github/ehayik/jmaskify/JsonMaskerTests.java
+++ b/src/test/java/io/github/ehayik/jmaskify/JsonMaskerTests.java
@@ -82,7 +82,6 @@ class JsonMaskerTests {
                 .prettify(true)
                 .withProperty("phone", base64())
                 .withProperties(fixedLength(), "name", "email")
-                .build()
                 .apply(JSON_OBJECT);
 
         // Then
@@ -94,7 +93,6 @@ class JsonMaskerTests {
         // When
         var actual = JsonMasker.builder()
                 .withProperties(Set.of("name", "email", "street", "value"), fixedLength())
-                .build()
                 .apply(JSON_NESTED_OBJECT);
 
         // Then
@@ -111,7 +109,6 @@ class JsonMaskerTests {
                 .prettify(true)
                 .withProperty("phone", base64())
                 .withProperties(fixedLength(), "name", "email")
-                .build()
                 .applyToObject(person);
 
         // Then
@@ -161,7 +158,7 @@ class JsonMaskerTests {
 		{"email":"*****","phone":"123-456-7890"}
 		""";
 
-        var actual = JsonMasker.builder().withProperty("email").build().apply(givenJson);
+        var actual = JsonMasker.builder().withProperty("email").apply(givenJson);
 
         // Then
         JSONAssert.assertEquals(expectedJson, actual, STRICT);
@@ -177,8 +174,7 @@ class JsonMaskerTests {
 		{"email":"*****","phone":"************"}
 		""";
 
-        var actual =
-                JsonMasker.builder().withProperties("email", "phone").build().apply(givenJson);
+        var actual = JsonMasker.builder().withProperties("email", "phone").apply(givenJson);
 
         // Then
         JSONAssert.assertEquals(expectedJson, actual, STRICT);
@@ -194,10 +190,8 @@ class JsonMaskerTests {
 		{"email":"*****","phone":"************"}
 		""";
 
-        var actual = JsonMasker.builder()
-                .withProperties(Set.of("email", "phone"))
-                .build()
-                .apply(givenJson);
+        var actual =
+                JsonMasker.builder().withProperties(Set.of("email", "phone")).apply(givenJson);
 
         // Then
         JSONAssert.assertEquals(expectedJson, actual, STRICT);

--- a/src/test/java/io/github/ehayik/jmaskify/MaskingCombinationTests.java
+++ b/src/test/java/io/github/ehayik/jmaskify/MaskingCombinationTests.java
@@ -1,0 +1,37 @@
+package io.github.ehayik.jmaskify;
+
+import static io.github.ehayik.jmaskify.Masker.base64;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class MaskingCombinationTests {
+
+    @Test
+    void shouldApplyMaskingStrategiesSequence() {
+        // Given
+        var json = """
+		{
+		"name": "John Doe",
+		"logs": [
+			"2023-05-15 INFO IP Address: 192.168.1.1"
+		]
+		}
+""";
+
+        var jsonMasker = Masker.json()
+                .withProperty("name", Masker.delegate(value -> "■■■■■■"))
+                .build();
+
+        var multilineMasker = Masker.multilinePattern()
+                .withMaskPattern("(\\d+\\.\\d+\\.\\d+\\.\\d+)")
+                .build();
+
+        var compositeMasker = jsonMasker.andThen(multilineMasker).andThen(base64());
+
+        // When - Then
+        assertThat(compositeMasker.apply(json))
+                .isEqualTo(
+                        "eyJuYW1lIjoi4pag4pag4pag4pag4pag4pagIiwibG9ncyI6WyIyMDIzLTA1LTE1IElORk8gSVAgQWRkcmVzczogKioqKioqKioqKioiXX0=");
+    }
+}

--- a/src/test/java/io/github/ehayik/jmaskify/MultilinePatternMaskerTests.java
+++ b/src/test/java/io/github/ehayik/jmaskify/MultilinePatternMaskerTests.java
@@ -2,9 +2,13 @@ package io.github.ehayik.jmaskify;
 
 import static org.apache.commons.lang3.StringUtils.repeat;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import net.datafaker.Faker;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class MultilinePatternMaskerTests {
 
@@ -68,5 +72,21 @@ class MultilinePatternMaskerTests {
 
         // When -Then
         assertThat(masker.apply(inputValue)).isEqualTo(expectedValue);
+    }
+
+    @Test
+    void shouldFailsWhenNoPatternAddedToBuilder() {
+        assertThatThrownBy(() -> Masker.multilinePattern().apply("Hello World!"))
+                .isInstanceOf(MaskingException.class)
+                .hasMessage("Mask patterns cannot be empty");
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = " ")
+    void shouldFailsWhenMaskPatternIsBlank(String maskPattern) {
+        assertThatThrownBy(() -> Masker.multilinePattern().withMaskPattern(maskPattern).apply("Hello World!"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Mask pattern cannot be blank");
     }
 }

--- a/src/test/java/io/github/ehayik/jmaskify/MultilinePatternMaskerTests.java
+++ b/src/test/java/io/github/ehayik/jmaskify/MultilinePatternMaskerTests.java
@@ -18,7 +18,7 @@ class MultilinePatternMaskerTests {
         var username = FAKER.internet().username();
         var inputValue = "This is username=%s sensitive data.".formatted(username);
         var expectedValue = "This is username=%s sensitive data.".formatted(repeat("*", username.length()));
-        var masker = Masker.multilinePattern().withMaskPattern(USERNAME_PATTERN).build();
+        var masker = Masker.multilinePattern().withMaskPattern(USERNAME_PATTERN);
 
         // When -Then
         assertThat(masker.apply(inputValue)).isEqualTo(expectedValue);
@@ -42,10 +42,7 @@ class MultilinePatternMaskerTests {
 		"""
                 .formatted(repeat("*", username.length()), repeat("*", ipAddress.length()));
 
-        var masker = Masker.multilinePattern()
-                .withMaskPattern(USERNAME_PATTERN)
-                .withMaskPattern(IP_ADDRESS_PATTERN)
-                .build();
+        var masker = Masker.multilinePattern().withMaskPattern(USERNAME_PATTERN).withMaskPattern(IP_ADDRESS_PATTERN);
 
         // When -Then
         assertThat(masker.apply(inputValue)).isEqualTo(expectedValue);
@@ -54,8 +51,7 @@ class MultilinePatternMaskerTests {
     @Test
     void shouldNotMaskNull() {
         // Given
-        var masker =
-                Masker.multilinePattern().withMaskPattern(IP_ADDRESS_PATTERN).build();
+        var masker = Masker.multilinePattern().withMaskPattern(IP_ADDRESS_PATTERN);
 
         // When - Then
         assertThat(masker.apply(null)).isNull();
@@ -67,10 +63,8 @@ class MultilinePatternMaskerTests {
         var ipAddress = FAKER.internet().ipV4Address();
         var inputValue = "This is %s sensitive data.".formatted(ipAddress);
         var expectedValue = "This is %s sensitive data.".formatted(repeat("#", ipAddress.length()));
-        var masker = Masker.multilinePattern()
-                .withMaskPattern(IP_ADDRESS_PATTERN)
-                .withSubstitution('#')
-                .build();
+        var masker =
+                Masker.multilinePattern().withMaskPattern(IP_ADDRESS_PATTERN).withSubstitution('#');
 
         // When -Then
         assertThat(masker.apply(inputValue)).isEqualTo(expectedValue);


### PR DESCRIPTION
### Why

To streamline the API usage and improve code readability. 
The Pull Request simplifies the building process of masking objects by removing redundant build() method calls.

### How

- Improve `JsonMasker` and `MultilinePatternMasker` builders.
     -  Add utility methods `apply`, `applyToObject`, and `andThen` to enhance functionality and chaining.
- Update documentation
     - Added detailed Javadoc comments for new methods in the main classes.
     - Remove unnecessary `.build()` calls in README example code for clarity and consistency.  
- Update tests accordingly
   -  Simplify existing test cases by removing unnecessary build() calls.
   - Introduce a new test class, `MaskingCombinationTests`, to verify the composition of multiple masking strategies.