### PR TITLE
Add support for masking array values in JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,14 @@ String json = """
 {
   "name": "John Doe",
   "age": 30,
-  "email": "john.doe@example.com",
-  "phone": "123-456-7890",
-  "creditCard": "4289-3874-8064-8976"
+  "contactInfo": {
+    "email": "john.doe@example.com",
+    "phone": "123-456-7890"
+  },
+  "creditCards": [
+     "1234-5678-9012-3456",
+     "4289-3874-8064-8976"
+  ]
 }
 """;
 
@@ -111,18 +116,23 @@ var masker = Masker.json()
     .prettify(true)
     .withProperty("email") // Default fixed pattern masking
     .withProperty("phone", Masker.base64())
-    .withProperty("creditCard", Masker.creditCard('X'))    
-    .withProperty("name", Masker.delegate(value -> "MASKED"));
+    .withProperty("creditCards", Masker.creditCard('X'))    
+    .withProperty("name", Masker.delegate(value -> "■■■■■■"));
 
 // Apply masking
 var maskedJson = masker.apply(json);
 /*
  Result: {
-            "name": "MASKED",
+            "name": "■■■■■■",
             "age": 30,
-            "email": "***************",
-            "phone": "MTIzLTQ1Ni03ODkw",
-            "creditCard": "XXXX-XXXX-XXXX-8976"
+            "contactInfo": {
+              "email": "***************",
+              "phone": "MTIzLTQ1Ni03ODkw"
+            },
+            "creditCards": [
+			  "XXXX-XXXX-XXXX-3456",
+			  "XXXX-XXXX-XXXX-8976"
+			]
           }
  */
 ```

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ String json = """
     "email": "john.doe@example.com",
     "phone": "123-456-7890"
   },
-  "creditCards": "1234-5678-9012-3456"
+  "creditCard": "1234-5678-9012-3456"
 }
 """;
 

--- a/README.md
+++ b/README.md
@@ -104,10 +104,7 @@ String json = """
     "email": "john.doe@example.com",
     "phone": "123-456-7890"
   },
-  "creditCards": [
-     "1234-5678-9012-3456",
-     "4289-3874-8064-8976"
-  ]
+  "creditCards": "1234-5678-9012-3456"
 }
 """;
 
@@ -116,7 +113,7 @@ var masker = Masker.json()
     .prettify(true)
     .withProperty("email") // Default fixed pattern masking
     .withProperty("phone", Masker.base64())
-    .withProperty("creditCards", Masker.creditCard('X'))    
+    .withProperty("creditCard", Masker.creditCard('X'))    
     .withProperty("name", Masker.delegate(value -> "■■■■■■"));
 
 // Apply masking
@@ -129,10 +126,7 @@ var maskedJson = masker.apply(json);
               "email": "***************",
               "phone": "MTIzLTQ1Ni03ODkw"
             },
-            "creditCards": [
-			  "XXXX-XXXX-XXXX-3456",
-			  "XXXX-XXXX-XXXX-8976"
-			]
+            "creditCard": "XXXX-XXXX-XXXX-3456"
           }
  */
 ```
@@ -140,13 +134,121 @@ var maskedJson = masker.apply(json);
 > **NOTE**:
 > Non-string values (numbers, booleans, nulls) are preserved without masking.
 
-> **NOTE**: Masking string values within a JSON array
-> 
-> - Direct string elements of the array
-> - String values within nested objects inside the array
-> - Some string values within nested arrays, depending on their position and structure
+##### Masking string values within a JSON array
 
-### 3. Multiline Text Masking
+JMaskify provides powerful capabilities for masking string values within JSON arrays.
+Here are examples of different array masking scenarios:
+
+###### Example 1: Simple Array of Strings
+
+When you need to mask an array of sensitive string values, such as credit card numbers:
+
+```java
+String json = """
+{
+    "name": "John Doe",
+    "creditCards": [
+        "1234-5678-9012-3456",
+        "4289-3874-8064-8976"
+    ]
+}
+""";
+
+var masker = JsonMasker.builder()
+    .withProperty("creditCards", Masker.creditCard('X'))
+    .build();
+
+var maskedJson = masker.apply(json);
+
+/* Result:
+{
+    "name": "John Doe",
+    "creditCards": [
+        "XXXX-XXXX-XXXX-3456",
+        "XXXX-XXXX-XXXX-8976"
+    ]
+}
+*/
+```
+
+###### Example 2: Arrays with Mixed Value Types
+
+JMaskify can handle arrays containing a mix of different value types, masking only the string values:
+
+```java
+String json = """
+{
+    "name": "John Doe",
+    "mixedArray": [
+        "sensitive-string-data",
+        42,
+        true,
+        null,
+        {"nestedKey": "nestedValue"},
+        ["nested", "array"]
+    ]
+}
+""";
+
+var masker = JsonMasker.builder()
+    .withProperty("mixedArray", Masker.fixedLength())
+    .build();
+
+var maskedJson = masker.apply(json);
+
+/* Result:
+{
+    "name": "John Doe",
+    "mixedArray": [
+        "*********************",
+        42,
+        true,
+        null,
+        {"nestedKey": "***********"},
+        ["******", "*****"]
+    ]
+}
+*/
+```
+
+###### Example 3: Nested Arrays
+
+JMaskify handles nested arrays with specific masking behavior:
+
+```java
+String json = """
+{
+    "name": "John Doe",
+    "nestedArrays": [
+        ["sensitive-outer-inner", "another-value"],
+        42,
+        ["not-masked-1", "not-masked-2"]
+    ]
+}
+""";
+
+var masker = JsonMasker.builder()
+    .withProperty("nestedArrays", Masker.fixedLength())
+    .build();
+
+var maskedJson = masker.apply(json);
+
+/* Result:
+{
+    "name": "John Doe",
+    "nestedArrays": [
+        ["*********************", "*************"],
+        42,
+        ["************", "************"]
+    ]
+}
+*/
+```
+
+> **NOTE**: This example demonstrates how JMaskify recursively processes nested arrays. 
+> All string values within nested arrays are masked consistently, regardless of their position or nesting level.
+
+#### 3. Multiline Text Masking
 
 When working with log files or other text that spans multiple lines, you can use multiline text masking to identify and mask patterns:
 
@@ -185,7 +287,7 @@ var masker = Masker.delegate((String input) -> {
 
     var first = input.charAt(0);
     var last = input.charAt(input.length() - 1);
-    
+
     return first +
            "*".repeat(input.length() - 2) +
            last;
@@ -255,14 +357,12 @@ JMaskify provides robust handling for invalid inputs.
 For instance, attempting to mask invalid JSON results in exceptions with clear error messages:
 
 ```java
+// Create a masker for email fields
 var masker = Masker.json().withProperty("email").build();
 
-var exception = assertThrows(MaskingException.class, () -> masker.apply("///"));
-
-var expectedMessage = "Failed to mask JSON content";
-var actualMessage = exception.getMessage();
-
-assertTrue(actualMessage.contains(expectedMessage));
+// When applying to invalid JSON, a MaskingException will be thrown
+// with the message "Failed to mask JSON content"
+// masker.apply("///");  // This would throw MaskingException
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ var maskedJson = masker.apply(json);
  */
 ```
 
+> **NOTE**:
+> Non-string values (numbers, booleans, nulls) are preserved without masking.
+
+> **NOTE**: Masking string values within a JSON array
+> 
+> - Direct string elements of the array
+> - String values within nested objects inside the array
+> - Some string values within nested arrays, depending on their position and structure
+
 ### 3. Multiline Text Masking
 
 When working with log files or other text that spans multiple lines, you can use multiline text masking to identify and mask patterns:

--- a/src/main/java/io/github/ehayik/jmaskify/JsonMasker.java
+++ b/src/main/java/io/github/ehayik/jmaskify/JsonMasker.java
@@ -1,7 +1,6 @@
 package io.github.ehayik.jmaskify;
 
-import static com.fasterxml.jackson.core.JsonToken.FIELD_NAME;
-import static com.fasterxml.jackson.core.JsonToken.VALUE_STRING;
+import static com.fasterxml.jackson.core.JsonToken.*;
 import static java.util.Objects.requireNonNullElseGet;
 
 import com.fasterxml.jackson.core.JsonFactory;
@@ -20,6 +19,7 @@ import java.util.Set;
 import java.util.function.Function;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -172,13 +172,38 @@ public final class JsonMasker implements Masker<String> {
             return;
         }
 
+        if (masker != null && token == START_ARRAY) {
+            maskArrayValues(fieldName, masker, generator, parser);
+            return;
+        }
+
         if (masker == null) {
             log.debug("No masker found for field: {}", fieldName);
         } else {
-            log.debug("Ignoring field: {}. Only fields of type String will be masked.", fieldName);
+            log.debug("Ignoring field: {}. Only values of type String will be masked.", fieldName);
         }
 
         generator.copyCurrentEvent(parser);
+    }
+
+    @SneakyThrows
+    private void maskArrayValues(String fieldName, Masker<String> masker, JsonGenerator generator, JsonParser parser) {
+        generator.writeStartArray();
+        var valueToken = parser.nextToken();
+
+        while (valueToken != null && valueToken != END_ARRAY) {
+
+            if (valueToken == VALUE_STRING) {
+                generator.writeString(masker.apply(parser.getValueAsString()));
+            } else {
+                log.debug("Ignoring array: {} values. Only values of type String will be masked.", fieldName);
+                generator.copyCurrentEvent(parser);
+            }
+
+            valueToken = parser.nextToken();
+        }
+
+        generator.writeEndArray();
     }
 
     /**

--- a/src/main/java/io/github/ehayik/jmaskify/JsonMasker.java
+++ b/src/main/java/io/github/ehayik/jmaskify/JsonMasker.java
@@ -191,13 +191,9 @@ public final class JsonMasker implements Masker<String> {
      * This implementation masks:
      * - Direct string elements of the array
      * - String values within nested objects inside the array
-     * - Some string values within nested arrays, depending on their position and structure
+     * - String values within nested arrays (recursively)
      * <p>
      * Non-string values (numbers, booleans, nulls) are preserved without masking.
-     * <p>
-     * Note: The behavior for nested arrays is complex and may vary depending on the structure
-     * of the JSON.
-     * Not all string values in all nested arrays will be masked.
      *
      * @param fieldName the name of the field containing the array
      * @param masker the masking strategy to apply to string values
@@ -205,14 +201,17 @@ public final class JsonMasker implements Masker<String> {
      * @param parser the JSON parser to read the array values
      * @throws IOException if an I/O error occurs during JSON processing
      */
-    private void maskArrayValues(String fieldName, Masker<String> masker, JsonGenerator generator, JsonParser parser) throws IOException {
+    private void maskArrayValues(String fieldName, Masker<String> masker, JsonGenerator generator, JsonParser parser)
+            throws IOException {
         generator.writeStartArray();
         var valueToken = parser.nextToken();
 
         while (valueToken != null && valueToken != END_ARRAY) {
-
             if (valueToken == VALUE_STRING) {
                 generator.writeString(masker.apply(parser.getValueAsString()));
+            } else if (valueToken == START_ARRAY) {
+                // Recursively process nested arrays
+                maskArrayValues(fieldName, masker, generator, parser);
             } else {
                 log.debug("Ignoring array: {} value. Only values of type String will be masked.", fieldName);
                 generator.copyCurrentEvent(parser);

--- a/src/main/java/io/github/ehayik/jmaskify/JsonMasker.java
+++ b/src/main/java/io/github/ehayik/jmaskify/JsonMasker.java
@@ -19,7 +19,6 @@ import java.util.Set;
 import java.util.function.Function;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -167,27 +166,46 @@ public final class JsonMasker implements Masker<String> {
 
         var masker = properties.get(fieldName);
 
-        if (masker != null && token == VALUE_STRING) {
+        if (masker == null) {
+            log.debug("Ignoring field: {}. No masker found.", fieldName);
+            generator.copyCurrentEvent(parser);
+            return;
+        }
+
+        if (token == VALUE_STRING) {
             generator.writeString(masker.apply(parser.getValueAsString()));
             return;
         }
 
-        if (masker != null && token == START_ARRAY) {
+        if (token == START_ARRAY) {
             maskArrayValues(fieldName, masker, generator, parser);
             return;
         }
 
-        if (masker == null) {
-            log.debug("No masker found for field: {}", fieldName);
-        } else {
-            log.debug("Ignoring field: {}. Only values of type String will be masked.", fieldName);
-        }
-
+        log.debug("Ignoring field: {}. Only values of type String will be masked.", fieldName);
         generator.copyCurrentEvent(parser);
     }
 
-    @SneakyThrows
-    private void maskArrayValues(String fieldName, Masker<String> masker, JsonGenerator generator, JsonParser parser) {
+    /**
+     * Masks string values within a JSON array.
+     * This implementation masks:
+     * - Direct string elements of the array
+     * - String values within nested objects inside the array
+     * - Some string values within nested arrays, depending on their position and structure
+     * <p>
+     * Non-string values (numbers, booleans, nulls) are preserved without masking.
+     * <p>
+     * Note: The behavior for nested arrays is complex and may vary depending on the structure
+     * of the JSON.
+     * Not all string values in all nested arrays will be masked.
+     *
+     * @param fieldName the name of the field containing the array
+     * @param masker the masking strategy to apply to string values
+     * @param generator the JSON generator to write the masked array
+     * @param parser the JSON parser to read the array values
+     * @throws IOException if an I/O error occurs during JSON processing
+     */
+    private void maskArrayValues(String fieldName, Masker<String> masker, JsonGenerator generator, JsonParser parser) throws IOException {
         generator.writeStartArray();
         var valueToken = parser.nextToken();
 
@@ -196,7 +214,7 @@ public final class JsonMasker implements Masker<String> {
             if (valueToken == VALUE_STRING) {
                 generator.writeString(masker.apply(parser.getValueAsString()));
             } else {
-                log.debug("Ignoring array: {} values. Only values of type String will be masked.", fieldName);
+                log.debug("Ignoring array: {} value. Only values of type String will be masked.", fieldName);
                 generator.copyCurrentEvent(parser);
             }
 

--- a/src/test/java/io/github/ehayik/jmaskify/JsonMaskerTests.java
+++ b/src/test/java/io/github/ehayik/jmaskify/JsonMaskerTests.java
@@ -234,5 +234,83 @@ class JsonMaskerTests {
         JSONAssert.assertEquals(expectedJson, actualJson, STRICT);
     }
 
+    @Test
+    void shouldMaskMixedTypeArrayValues() throws Exception {
+        // Given
+        String givenJson =
+                """
+		{
+			"name": "John Doe",
+			"mixedArray": [
+				"sensitive-string-data",
+				42,
+				true,
+				null,
+				{"nestedKey": "nestedValue"},
+				["nested", "array"]
+			]
+		}
+		""";
+
+        String expectedJson =
+                """
+		{
+			"name": "John Doe",
+			"mixedArray": [
+				"*********************",
+				42,
+				true,
+				null,
+				{"nestedKey": "***********"},
+				["******", "*****"]
+			]
+		}
+		""";
+
+        var actualJson = JsonMasker.builder()
+                .withProperty("mixedArray", fixedLength())
+                .build()
+                .apply(givenJson);
+
+        // Then
+        JSONAssert.assertEquals(expectedJson, actualJson, STRICT);
+    }
+
+    @Test
+    void shouldMaskNestedArrayStringValues() throws Exception {
+        // Given
+        String givenJson =
+                """
+		{
+			"name": "John Doe",
+			"nestedArrays": [
+				["sensitive-outer-inner", "another-value"],
+				42,
+				["not-masked-1", "not-masked-2"]
+			]
+		}
+		""";
+
+        String expectedJson =
+                """
+		{
+			"name": "John Doe",
+			"nestedArrays": [
+				["*********************", "*************"],
+				42,
+				["not-masked-1", "not-masked-2"]
+			]
+		}
+		""";
+
+        var actualJson = JsonMasker.builder()
+                .withProperty("nestedArrays", fixedLength())
+                .build()
+                .apply(givenJson);
+
+        // Then
+        JSONAssert.assertEquals(expectedJson, actualJson, STRICT);
+    }
+
     record Person(String name, int age, String city, String email, String phone) {}
 }

--- a/src/test/java/io/github/ehayik/jmaskify/JsonMaskerTests.java
+++ b/src/test/java/io/github/ehayik/jmaskify/JsonMaskerTests.java
@@ -174,6 +174,7 @@ class JsonMaskerTests {
 		{"email":"*****","phone":"************"}
 		""";
 
+        // When
         var actual = JsonMasker.builder().withProperties("email", "phone").apply(givenJson);
 
         // Then
@@ -195,6 +196,42 @@ class JsonMaskerTests {
 
         // Then
         JSONAssert.assertEquals(expectedJson, actual, STRICT);
+    }
+
+    @Test
+    void shouldMaskNestedArrayValues() throws Exception {
+        // Given
+        String givenJson =
+                """
+		{
+			"name": "John Doe",
+			"age": 30,
+			"creditCards": [
+				"1234-5678-9012-3456",
+				"4289-3874-8064-8976"
+			]
+		}
+		""";
+
+        String expectedJson =
+                """
+		{
+			"name": "John Doe",
+			"age": 30,
+			"creditCards": [
+				"XXXX-XXXX-XXXX-3456",
+				"XXXX-XXXX-XXXX-8976"
+			]
+		}
+		""";
+
+        var actualJson = JsonMasker.builder()
+                .withProperty("creditCards", Masker.creditCard('X'))
+                .build()
+                .apply(givenJson);
+
+        // Then
+        JSONAssert.assertEquals(expectedJson, actualJson, STRICT);
     }
 
     record Person(String name, int age, String city, String email, String phone) {}

--- a/src/test/java/io/github/ehayik/jmaskify/JsonMaskerTests.java
+++ b/src/test/java/io/github/ehayik/jmaskify/JsonMaskerTests.java
@@ -290,7 +290,6 @@ class JsonMaskerTests {
 			]
 		}
 		""";
-
         String expectedJson =
                 """
 		{
@@ -298,7 +297,7 @@ class JsonMaskerTests {
 			"nestedArrays": [
 				["*********************", "*************"],
 				42,
-				["not-masked-1", "not-masked-2"]
+				["************", "************"]
 			]
 		}
 		""";

--- a/src/test/java/io/github/ehayik/jmaskify/MultilinePatternMaskerTests.java
+++ b/src/test/java/io/github/ehayik/jmaskify/MultilinePatternMaskerTests.java
@@ -85,7 +85,8 @@ class MultilinePatternMaskerTests {
     @NullAndEmptySource
     @ValueSource(strings = " ")
     void shouldFailsWhenMaskPatternIsBlank(String maskPattern) {
-        assertThatThrownBy(() -> Masker.multilinePattern().withMaskPattern(maskPattern).apply("Hello World!"))
+        assertThatThrownBy(() ->
+                        Masker.multilinePattern().withMaskPattern(maskPattern).apply("Hello World!"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Mask pattern cannot be blank");
     }


### PR DESCRIPTION
### Why

To  introduce enhancements to the JsonMasker functionality, particularly for masking string values inside JSON arrays, mixed-type arrays, and nested arrays. 

### How

- Add functionality to handle and mask string values inside JSON arrays, including nested arrays, while preserving non-string values.
- Update masking logic to log fields ignored due to missing or unsupported masking strategies.
- Expand examples in the README to illustrate array and nested array masking capabilities.
