### PR TITLE
Add custom substitution character configuration in fixed-length masker

### DIFF
--- a/src/main/java/io/github/ehayik/jmaskify/FixedLengthMasker.java
+++ b/src/main/java/io/github/ehayik/jmaskify/FixedLengthMasker.java
@@ -18,7 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 public final class FixedLengthMasker implements Masker<String> {
 
     private final int fixedLength;
-    private final char substitutionChar;
+    private final char substitution;
 
     public static Builder builder() {
         return new Builder();
@@ -55,10 +55,10 @@ public final class FixedLengthMasker implements Masker<String> {
 
         if (fixedLength <= 0) {
             log.debug("Fixed length is less than or equal to zero. Using value length as fixed length.");
-            return repeat(substitutionChar, value.length());
+            return repeat(substitution, value.length());
         }
 
-        return repeat(substitutionChar, fixedLength);
+        return repeat(substitution, fixedLength);
     }
 
     /**
@@ -67,7 +67,7 @@ public final class FixedLengthMasker implements Masker<String> {
     public static final class Builder implements MaskerBuilder<String, FixedLengthMasker> {
 
         private int fixedLength;
-        private char substitutionChar = DEF_SUBSTITUTION_CHAR;
+        private char substitution = DEF_SUBSTITUTION_CHAR;
 
         /**
          * Sets the fixed length for the masker.
@@ -85,12 +85,12 @@ public final class FixedLengthMasker implements Masker<String> {
         /**
          * Sets the substitution character for the masker.
          *
-         * @param substitutionChar the character to use for masking.
+         * @param substitution the character to use for masking.
          *                        If not specified, defaults to {@link Masker#DEF_SUBSTITUTION_CHAR}.
          * @return this builder for method chaining
          */
-        public Builder withSubstitutionChar(char substitutionChar) {
-            this.substitutionChar = substitutionChar;
+        public Builder withSubstitution(char substitution) {
+            this.substitution = substitution;
             return this;
         }
 
@@ -101,7 +101,7 @@ public final class FixedLengthMasker implements Masker<String> {
          */
         @Override
         public FixedLengthMasker build() {
-            return new FixedLengthMasker(fixedLength, substitutionChar);
+            return new FixedLengthMasker(fixedLength, substitution);
         }
     }
 }

--- a/src/main/java/io/github/ehayik/jmaskify/FixedLengthMasker.java
+++ b/src/main/java/io/github/ehayik/jmaskify/FixedLengthMasker.java
@@ -82,6 +82,13 @@ public final class FixedLengthMasker implements Masker<String> {
             return this;
         }
 
+        /**
+         * Sets the substitution character for the masker.
+         *
+         * @param substitutionChar the character to use for masking.
+         *                        If not specified, defaults to {@link Masker#DEF_SUBSTITUTION_CHAR}.
+         * @return this builder for method chaining
+         */
         public Builder withSubstitutionChar(char substitutionChar) {
             this.substitutionChar = substitutionChar;
             return this;

--- a/src/main/java/io/github/ehayik/jmaskify/FixedLengthMasker.java
+++ b/src/main/java/io/github/ehayik/jmaskify/FixedLengthMasker.java
@@ -18,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 public final class FixedLengthMasker implements Masker<String> {
 
     private final int fixedLength;
+    private final char substitutionChar;
 
     public static Builder builder() {
         return new Builder();
@@ -28,7 +29,7 @@ public final class FixedLengthMasker implements Masker<String> {
      */
     @Deprecated
     public FixedLengthMasker() {
-        this(0);
+        this(0, DEF_SUBSTITUTION_CHAR);
     }
 
     /**
@@ -54,10 +55,10 @@ public final class FixedLengthMasker implements Masker<String> {
 
         if (fixedLength <= 0) {
             log.debug("Fixed length is less than or equal to zero. Using value length as fixed length.");
-            return repeat(DEF_SUBSTITUTION_CHAR, value.length());
+            return repeat(substitutionChar, value.length());
         }
 
-        return repeat(DEF_SUBSTITUTION_CHAR, fixedLength);
+        return repeat(substitutionChar, fixedLength);
     }
 
     /**
@@ -65,7 +66,8 @@ public final class FixedLengthMasker implements Masker<String> {
      */
     public static final class Builder implements MaskerBuilder<String, FixedLengthMasker> {
 
-        private int fixedLength = 0;
+        private int fixedLength;
+        private char substitutionChar = DEF_SUBSTITUTION_CHAR;
 
         /**
          * Sets the fixed length for the masker.
@@ -80,6 +82,11 @@ public final class FixedLengthMasker implements Masker<String> {
             return this;
         }
 
+        public Builder withSubstitutionChar(char substitutionChar) {
+            this.substitutionChar = substitutionChar;
+            return this;
+        }
+
         /**
          * Builds and returns a new {@link FixedLengthMasker} instance with the configured settings.
          *
@@ -87,7 +94,7 @@ public final class FixedLengthMasker implements Masker<String> {
          */
         @Override
         public FixedLengthMasker build() {
-            return new FixedLengthMasker(fixedLength);
+            return new FixedLengthMasker(fixedLength, substitutionChar);
         }
     }
 }

--- a/src/test/java/io/github/ehayik/jmaskify/FixedLengthMaskerTests.java
+++ b/src/test/java/io/github/ehayik/jmaskify/FixedLengthMaskerTests.java
@@ -53,7 +53,7 @@ class FixedLengthMaskerTests {
         var expectedText = repeat("■", text.length());
 
         // When
-        var actualText = Masker.fixedLength().withSubstitutionChar('■').apply(text);
+        var actualText = Masker.fixedLength().withSubstitution('■').apply(text);
 
         // Then
         assertThat(actualText).isEqualTo(expectedText);

--- a/src/test/java/io/github/ehayik/jmaskify/FixedLengthMaskerTests.java
+++ b/src/test/java/io/github/ehayik/jmaskify/FixedLengthMaskerTests.java
@@ -14,7 +14,7 @@ class FixedLengthMaskerTests {
     @ValueSource(strings = {"", " ", "   ", "Hello World!"})
     void shouldMaskStringToFixedLength(String text) {
         // Given
-        var masker = Masker.fixedLength(4);
+        var masker = Masker.fixedLength().withFixedLength(4);
 
         // When
         var actualText = masker.apply(text);

--- a/src/test/java/io/github/ehayik/jmaskify/FixedLengthMaskerTests.java
+++ b/src/test/java/io/github/ehayik/jmaskify/FixedLengthMaskerTests.java
@@ -3,6 +3,7 @@ package io.github.ehayik.jmaskify;
 import static org.apache.commons.lang3.StringUtils.repeat;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import net.datafaker.Faker;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -43,5 +44,18 @@ class FixedLengthMaskerTests {
 
         // When - Then
         assertThat(masker.apply(null)).isNull();
+    }
+
+    @Test
+    void shouldMaskStringWithCustomSubstitution() {
+        // Given
+        var text = new Faker().finance().iban();
+        var expectedText = repeat("■", text.length());
+
+        // When
+        var actualText = Masker.fixedLength().withSubstitutionChar('■').apply(text);
+
+        // Then
+        assertThat(actualText).isEqualTo(expectedText);
     }
 }


### PR DESCRIPTION
### Why

To introduce a new feature that allows specifying a custom substitution character for the `FixedLengthMasker`.

```java
var masker = Masker.fixedLength(4).withSubstitution('#');  // Use # instead of *

var ssn = "123-45-6789";
var maskedSsn = masker.apply(ssn);
// Result: "###########"
```

### How

- Added a new `substitution` field to the `FixedLengthMasker` class, allowing customization of the substitution character.
- Updated the default constructor and related methods to use `substitution` instead of a predefined default character.
- Expanded the `FixedLengthMasker .Builder` class to include a new `withSubstitution` method for setting the substitution character.
- Modified existing tests to use the updated builder and added a new test verifying masking with a custom substitution character.