### PR TITLE
Simplify `fixedLength` method by removing deprecated builder chaining

### DIFF
--- a/src/main/java/io/github/ehayik/jmaskify/Masker.java
+++ b/src/main/java/io/github/ehayik/jmaskify/Masker.java
@@ -115,11 +115,9 @@ public sealed interface Masker<T> extends Function<T, String>
      * @param fixedLength the length to which the input string should be masked.
      *                    If the value is zero or negative, the input string is masked to the same length as the input string.
      * @return a Masker that replaces the input string with a fixed number of substitution characters.
-     * @deprecated Use {@link #fixedLength()}{@code .withFixedLength(int)} instead.
      */
-    @Deprecated
-    static Masker<String> fixedLength(int fixedLength) {
-        return fixedLength().withFixedLength(fixedLength).build();
+    static FixedLengthMasker.Builder fixedLength(int fixedLength) {
+        return fixedLength().withFixedLength(fixedLength);
     }
 
     /**

--- a/src/test/java/io/github/ehayik/jmaskify/FixedLengthMaskerTests.java
+++ b/src/test/java/io/github/ehayik/jmaskify/FixedLengthMaskerTests.java
@@ -80,8 +80,7 @@ class FixedLengthMaskerTests {
                 // pre-configured masker, expectedText
                 // Preserving suffix sections with fixed length
                 Arguments.of(
-                        Masker.fixedLength()
-                                .withFixedLength(4)
+                        Masker.fixedLength(4)
                                 .preservePrefix(2)
                                 .preserveSuffix(3)
                                 .build(),


### PR DESCRIPTION
### Why

To update the implementation of  `Masker#fixedLength(int fixedLength)` factory method. 
It removes a deprecated annotation and adjusts the method return type and usage accordingly.

### How

- Removed the `@Deprecated` annotation and updated the `fixedLength(int fixedLength)` method in `Masker` to return a builder instead of a completed masker instance.
- Updated the tests in `FixedLengthMaskerTests` to reflect the changes in the `fixedLength` method’s usage.
