### PR TITLE
Add support to configure masking strategies in multiline text masker

### DIFF
--- a/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
+++ b/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
@@ -153,7 +153,7 @@ public final class MultilinePatternMasker implements Masker<String> {
     public static final class Builder implements MaskerBuilder<String, MultilinePatternMasker> {
 
         private char substitution = DEF_SUBSTITUTION_CHAR;
-        private final List<String> defaultMaskerPatterns = new ArrayList<>();
+        private final Set<String> defaultMaskerPatterns = new HashSet<>();
         private final Map<String, Masker<String>> customMaskerPatterns = new HashMap<>();
 
         /**

--- a/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
+++ b/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
@@ -261,9 +261,7 @@ public final class MultilinePatternMasker implements Masker<String> {
          * based on the configured patterns and substitution character.
          *
          * @return a new {@link MultilinePatternMasker} instance
-         * @throws MaskingException if no patterns were added to the builder
-         * @implNote All the specified mask patterns will be combined into a single pattern
-         *          using the {@link Pattern#MULTILINE} flag.
+         * @throws IllegalStateException if no patterns were added to the builder
          */
         @Override
         public MultilinePatternMasker build() {

--- a/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
+++ b/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
@@ -161,8 +161,8 @@ public final class MultilinePatternMasker implements Masker<String> {
          *
          * @param maskPattern the regular expression pattern used for matching sensitive data
          * @return the builder instance for chaining method calls
-         * @throws IllegalArgumentException if {@code maskPattern} is {@code null} or blank
-         * @throws IllegalArgumentException if a duplicate pattern is detected
+         * @throws IllegalArgumentException if {@code maskPattern} is {@code null}, blank or
+         * a duplicate pattern is detected
          */
         public Builder withMaskPattern(String maskPattern) {
 
@@ -185,8 +185,8 @@ public final class MultilinePatternMasker implements Masker<String> {
          * @param pattern the regular expression pattern used for matching sensitive data
          * @param masker the masking strategy to apply to the matched pattern
          * @return the builder instance for chaining method calls
-         * @throws IllegalArgumentException if {@code pattern} is {@code null} or blank
-         * @throws IllegalArgumentException if a duplicate pattern is detected
+         * @throws IllegalArgumentException if {@code pattern} is {@code null}, blank or
+         * a duplicate pattern is detected
          * @throws NullPointerException if {@code masker} is {@code null}
          */
         public Builder withMaskPattern(String pattern, Masker<String> masker) {
@@ -211,8 +211,8 @@ public final class MultilinePatternMasker implements Masker<String> {
          * @param pattern the regular expression pattern used for matching sensitive data
          * @param maskerBuilder the masking strategy builder to build and apply to the matched pattern
          * @return the builder instance for chaining method calls
-         * @throws IllegalArgumentException if {@code pattern} is {@code null} or blank
-         * @throws IllegalArgumentException if a duplicate pattern is detected
+         * @throws IllegalArgumentException if {@code pattern} is {@code null}, blank or
+         * a duplicate pattern is detected
          * @throws NullPointerException if {@code maskerBuilder} is {@code null}
          */
         public Builder withMaskPattern(String pattern, MaskerBuilder<String, ?> maskerBuilder) {

--- a/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
+++ b/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
@@ -169,6 +169,11 @@ public final class MultilinePatternMasker implements Masker<String> {
                 throw new IllegalArgumentException("Mask pattern cannot be blank");
             }
 
+            if (customMaskerPatterns.containsKey(maskPattern)) {
+                throw new IllegalArgumentException(
+                        "Duplicate pattern detected: '%s' is already registered.".formatted(maskPattern));
+            }
+
             defaultMaskerPatterns.add(maskPattern);
             return this;
         }
@@ -268,7 +273,7 @@ public final class MultilinePatternMasker implements Masker<String> {
 
             if (defaultMaskerPatterns.isEmpty() && customMaskerPatterns.isEmpty()) {
                 throw new IllegalStateException(
-                        "At least one mask pattern must be specified. Use withMaskPattern() to add patterns.");
+                        "At least one masking pattern must be specified. Use withMaskPattern() to add patterns.");
             }
 
             return new MultilinePatternMasker(substitution, compileMultilinePattern(), compileCustomMaskerPatterns());

--- a/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
+++ b/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
@@ -269,8 +269,8 @@ public final class MultilinePatternMasker implements Masker<String> {
         @Override
         public MultilinePatternMasker build() {
 
-            if (defaultMaskerPatterns.isEmpty()) {
-                throw new MaskingException(
+            if (defaultMaskerPatterns.isEmpty() && customMaskerPatterns.isEmpty()) {
+                throw new IllegalStateException(
                         "At least one mask pattern must be specified. Use withMaskPattern() to add patterns.");
             }
 

--- a/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
+++ b/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
@@ -50,7 +50,10 @@ import org.jspecify.annotations.Nullable;
 public final class MultilinePatternMasker implements Masker<String> {
 
     private final char substitution;
+
+    @Nullable
     private final Pattern multilinePattern;
+
     private final Map<Pattern, Masker<String>> customMaskerPatterns;
 
     public static MultilinePatternMasker.Builder builder() {
@@ -82,7 +85,7 @@ public final class MultilinePatternMasker implements Masker<String> {
     private String applyCustomMaskerPatterns(String text) {
 
         if (customMaskerPatterns.isEmpty()) {
-            log.debug("No custom maskers were specified.");
+            log.debug("No custom masker patterns were specified.");
             return text;
         }
 
@@ -91,30 +94,35 @@ public final class MultilinePatternMasker implements Masker<String> {
         for (Map.Entry<Pattern, Masker<String>> entry : customMaskerPatterns.entrySet()) {
             var pattern = entry.getKey();
             var masker = entry.getValue();
-
-            // Compile the pattern
-            var customMatcher = pattern.matcher(result);
-
-            var customSb = new StringBuilder();
-
-            // Find and replace each match
-            while (customMatcher.find()) {
-                var matched = customMatcher.group(0);
-                var masked = masker.apply(matched);
-                // Quote the replacement string to avoid issues with special characters
-                customMatcher.appendReplacement(customSb, Matcher.quoteReplacement(masked));
-            }
-
-            customMatcher.appendTail(customSb);
-
-            // Update the result for the next pattern
-            result = customSb.toString();
+            result = applyCustomMaskerPattern(pattern, masker, result);
         }
 
         return result;
     }
 
+    private String applyCustomMaskerPattern(Pattern pattern, Masker<String> masker, String text) {
+        var matcher = pattern.matcher(text);
+        var sb = new StringBuilder();
+
+        // Find and replace each match
+        while (matcher.find()) {
+            var matched = matcher.group(0);
+            var masked = masker.apply(matched);
+            // Quote the replacement string to avoid issues with special characters
+            matcher.appendReplacement(sb, Matcher.quoteReplacement(masked));
+        }
+
+        matcher.appendTail(sb);
+        return sb.toString();
+    }
+
     private String applyMultilinePattern(String text) {
+
+        if (multilinePattern == null) {
+            log.debug("No default masker patterns were specified.");
+            return text;
+        }
+
         var sb = new StringBuilder(text);
         var matcher = multilinePattern.matcher(sb);
 
@@ -181,7 +189,7 @@ public final class MultilinePatternMasker implements Masker<String> {
                 throw new IllegalArgumentException("Pattern cannot be blank");
             }
 
-            defaultMaskerPatterns.add(pattern);
+            //            defaultMaskerPatterns.add(pattern);
             customMaskerPatterns.put(pattern, masker);
             return this;
         }
@@ -270,16 +278,14 @@ public final class MultilinePatternMasker implements Masker<String> {
             return new MultilinePatternMasker(substitution, compileMultilinePattern(), compileCustomMaskerPatterns());
         }
 
+        @Nullable
         private Pattern compileMultilinePattern() {
-            var multilinePattern = Pattern.compile(String.join("|", defaultMaskerPatterns), Pattern.MULTILINE);
-            var individualPatterns = Arrays.stream(multilinePattern.pattern().split("\\|", -1));
 
-            // Add patterns that don't have custom maskers
-            var patternsToMask = individualPatterns
-                    .filter(pattern -> !customMaskerPatterns.containsKey(pattern))
-                    .toList();
+            if (defaultMaskerPatterns.isEmpty()) {
+                return null;
+            }
 
-            return Pattern.compile(String.join("|", patternsToMask));
+            return Pattern.compile(String.join("|", defaultMaskerPatterns), Pattern.MULTILINE);
         }
 
         private Map<Pattern, Masker<String>> compileCustomMaskerPatterns() {

--- a/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
+++ b/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
@@ -1,10 +1,11 @@
 package io.github.ehayik.jmaskify;
 
+import static java.util.stream.Collectors.toMap;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 import java.util.function.Function;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
@@ -50,6 +51,7 @@ public final class MultilinePatternMasker implements Masker<String> {
 
     private final char substitution;
     private final Pattern multilinePattern;
+    private final Map<Pattern, Masker<String>> customMaskerPatterns;
 
     public static MultilinePatternMasker.Builder builder() {
         return new MultilinePatternMasker.Builder();
@@ -74,16 +76,60 @@ public final class MultilinePatternMasker implements Masker<String> {
             return null;
         }
 
+        return applyMultilinePattern(applyCustomMaskerPatterns(text));
+    }
+
+    private String applyCustomMaskerPatterns(String text) {
+
+        if (customMaskerPatterns.isEmpty()) {
+            log.debug("No custom maskers were specified.");
+            return text;
+        }
+
+        var result = text;
+
+        for (Map.Entry<Pattern, Masker<String>> entry : customMaskerPatterns.entrySet()) {
+            var pattern = entry.getKey();
+            var masker = entry.getValue();
+
+            // Compile the pattern
+            var customMatcher = pattern.matcher(result);
+
+            var customSb = new StringBuilder();
+
+            // Find and replace each match
+            while (customMatcher.find()) {
+                var matched = customMatcher.group(0);
+                var masked = masker.apply(matched);
+                // Quote the replacement string to avoid issues with special characters
+                customMatcher.appendReplacement(customSb, Matcher.quoteReplacement(masked));
+            }
+
+            customMatcher.appendTail(customSb);
+
+            // Update the result for the next pattern
+            result = customSb.toString();
+        }
+
+        return result;
+    }
+
+    private String applyMultilinePattern(String text) {
         var sb = new StringBuilder(text);
         var matcher = multilinePattern.matcher(sb);
 
         while (matcher.find()) {
-            IntStream.rangeClosed(1, matcher.groupCount()).forEach(group -> {
-                if (matcher.group(group) != null) {
-                    IntStream.range(matcher.start(group), matcher.end(group))
-                            .forEach(i -> sb.setCharAt(i, substitution));
-                }
-            });
+            // If no groups were captured, mask the entire match
+            if (matcher.groupCount() == 0) {
+                IntStream.range(matcher.start(), matcher.end()).forEach(i -> sb.setCharAt(i, substitution));
+            } else {
+                IntStream.rangeClosed(1, matcher.groupCount()).forEach(group -> {
+                    if (matcher.group(group) != null) {
+                        IntStream.range(matcher.start(group), matcher.end(group))
+                                .forEach(i -> sb.setCharAt(i, substitution));
+                    }
+                });
+            }
         }
 
         return sb.toString();
@@ -99,7 +145,8 @@ public final class MultilinePatternMasker implements Masker<String> {
     public static final class Builder implements MaskerBuilder<String, MultilinePatternMasker> {
 
         private char substitution = DEF_SUBSTITUTION_CHAR;
-        private final List<String> maskPatterns = new ArrayList<>();
+        private final List<String> defaultMaskerPatterns = new ArrayList<>();
+        private final Map<String, Masker<String>> customMaskerPatterns = new HashMap<>();
 
         /**
          * Adds a new regular expression pattern to the list of patterns that will
@@ -115,8 +162,47 @@ public final class MultilinePatternMasker implements Masker<String> {
                 throw new IllegalArgumentException("Mask pattern cannot be blank");
             }
 
-            maskPatterns.add(maskPattern);
+            defaultMaskerPatterns.add(maskPattern);
             return this;
+        }
+
+        /**
+         * Adds a new regular expression pattern with a specific masking strategy.
+         *
+         * @param pattern the regular expression pattern used for matching sensitive data
+         * @param masker the masking strategy to apply to the matched pattern
+         * @return the builder instance for chaining method calls
+         * @throws IllegalArgumentException if {@code pattern} is {@code null} or blank
+         * @throws NullPointerException if {@code masker} is {@code null}
+         */
+        public Builder withMaskPattern(String pattern, Masker<String> masker) {
+
+            if (isBlank(pattern)) {
+                throw new IllegalArgumentException("Pattern cannot be blank");
+            }
+
+            defaultMaskerPatterns.add(pattern);
+            customMaskerPatterns.put(pattern, masker);
+            return this;
+        }
+
+        /**
+         * Adds a new regular expression pattern with a specific masking strategy builder.
+         * The builder will be built to get the actual masker.
+         *
+         * @param pattern the regular expression pattern used for matching sensitive data
+         * @param maskerBuilder the masking strategy builder to build and apply to the matched pattern
+         * @return the builder instance for chaining method calls
+         * @throws IllegalArgumentException if {@code pattern} is {@code null} or blank
+         * @throws NullPointerException if {@code maskerBuilder} is {@code null}
+         */
+        public Builder withMaskPattern(String pattern, MaskerBuilder<String, ?> maskerBuilder) {
+
+            if (isBlank(pattern)) {
+                throw new IllegalArgumentException("Pattern cannot be blank");
+            }
+
+            return withMaskPattern(pattern, maskerBuilder.build());
         }
 
         /**
@@ -176,12 +262,29 @@ public final class MultilinePatternMasker implements Masker<String> {
         @Override
         public MultilinePatternMasker build() {
 
-            if (maskPatterns.isEmpty()) {
-                throw new MaskingException("Mask patterns cannot be empty");
+            if (defaultMaskerPatterns.isEmpty()) {
+                throw new MaskingException(
+                        "At least one mask pattern must be specified. Use withMaskPattern() to add patterns.");
             }
 
-            var multilinePattern = Pattern.compile(String.join("|", maskPatterns), Pattern.MULTILINE);
-            return new MultilinePatternMasker(substitution, multilinePattern);
+            return new MultilinePatternMasker(substitution, compileMultilinePattern(), compileCustomMaskerPatterns());
+        }
+
+        private Pattern compileMultilinePattern() {
+            var multilinePattern = Pattern.compile(String.join("|", defaultMaskerPatterns), Pattern.MULTILINE);
+            var individualPatterns = Arrays.stream(multilinePattern.pattern().split("\\|", -1));
+
+            // Add patterns that don't have custom maskers
+            var patternsToMask = individualPatterns
+                    .filter(pattern -> !customMaskerPatterns.containsKey(pattern))
+                    .toList();
+
+            return Pattern.compile(String.join("|", patternsToMask));
+        }
+
+        private Map<Pattern, Masker<String>> compileCustomMaskerPatterns() {
+            return customMaskerPatterns.entrySet().stream()
+                    .collect(toMap(entry -> Pattern.compile(entry.getKey()), Map.Entry::getValue));
         }
     }
 }

--- a/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
+++ b/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
@@ -4,6 +4,7 @@ import static java.util.stream.Collectors.toMap;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.util.*;
+import java.util.Map.Entry;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -91,10 +92,8 @@ public final class MultilinePatternMasker implements Masker<String> {
 
         var result = text;
 
-        for (Map.Entry<Pattern, Masker<String>> entry : customMaskerPatterns.entrySet()) {
-            var pattern = entry.getKey();
-            var masker = entry.getValue();
-            result = applyCustomMaskerPattern(pattern, masker, result);
+        for (var entry : customMaskerPatterns.entrySet()) {
+            result = applyCustomMaskerPattern(entry.getKey(), entry.getValue(), result);
         }
 
         return result;
@@ -289,7 +288,7 @@ public final class MultilinePatternMasker implements Masker<String> {
 
         private Map<Pattern, Masker<String>> compileCustomMaskerPatterns() {
             return customMaskerPatterns.entrySet().stream()
-                    .collect(toMap(entry -> Pattern.compile(entry.getKey()), Map.Entry::getValue));
+                    .collect(toMap(entry -> Pattern.compile(entry.getKey()), Entry::getValue));
         }
     }
 }

--- a/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
+++ b/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
@@ -162,6 +162,7 @@ public final class MultilinePatternMasker implements Masker<String> {
          * @param maskPattern the regular expression pattern used for matching sensitive data
          * @return the builder instance for chaining method calls
          * @throws IllegalArgumentException if {@code maskPattern} is {@code null} or blank
+         * @throws IllegalArgumentException if a duplicate pattern is detected
          */
         public Builder withMaskPattern(String maskPattern) {
 
@@ -185,6 +186,7 @@ public final class MultilinePatternMasker implements Masker<String> {
          * @param masker the masking strategy to apply to the matched pattern
          * @return the builder instance for chaining method calls
          * @throws IllegalArgumentException if {@code pattern} is {@code null} or blank
+         * @throws IllegalArgumentException if a duplicate pattern is detected
          * @throws NullPointerException if {@code masker} is {@code null}
          */
         public Builder withMaskPattern(String pattern, Masker<String> masker) {
@@ -210,6 +212,7 @@ public final class MultilinePatternMasker implements Masker<String> {
          * @param maskerBuilder the masking strategy builder to build and apply to the matched pattern
          * @return the builder instance for chaining method calls
          * @throws IllegalArgumentException if {@code pattern} is {@code null} or blank
+         * @throws IllegalArgumentException if a duplicate pattern is detected
          * @throws NullPointerException if {@code maskerBuilder} is {@code null}
          */
         public Builder withMaskPattern(String pattern, MaskerBuilder<String, ?> maskerBuilder) {

--- a/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
+++ b/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
@@ -29,8 +29,8 @@ import org.jspecify.annotations.Nullable;
  * // Create an instance of MultilinePatternMasker using the builder
  * MultilinePatternMasker masker = MultilinePatternMasker.builder()
  *     .withMaskPattern(usernamePattern)
- *     .withMaskPattern(ipAddressPattern)
- *     .withSubstitution('*')  // Define the substitution character
+ *     .withSubstitution('*')  // Define the substitution character for default masking strategy
+ *     .withMaskPattern(ipAddressPattern, Masker.fixedLength().withSubstitution('■').ignore('.'))
  *     .build();
  *
  * // Input string with sensitive data spread across multiple lines
@@ -42,7 +42,7 @@ import org.jspecify.annotations.Nullable;
  *
  * // Result: sensitive data is masked, i.e.,
  * // Line 1 with username=******* sensitive data.
- * // Line 2 ********** with more sensitive info.
+ * // Line 2 ■■■.■■■.■.■ with more sensitive info.
  * }
  * </pre>
  */
@@ -212,7 +212,7 @@ public final class MultilinePatternMasker implements Masker<String> {
         }
 
         /**
-         * Sets the substitution character to be used for replacing matched sensitive data.
+         * Sets the substitution character to be used for replacing matched sensitive data with the default masking strategy.
          *
          * <p>
          *      If not explicitly set, the default substitution character defined in the implementation

--- a/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
+++ b/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
@@ -209,11 +209,6 @@ public final class MultilinePatternMasker implements Masker<String> {
          * @throws NullPointerException if {@code maskerBuilder} is {@code null}
          */
         public Builder withMaskPattern(String pattern, MaskerBuilder<String, ?> maskerBuilder) {
-
-            if (isBlank(pattern)) {
-                throw new IllegalArgumentException("Pattern cannot be blank");
-            }
-
             return withMaskPattern(pattern, maskerBuilder.build());
         }
 

--- a/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
+++ b/src/main/java/io/github/ehayik/jmaskify/MultilinePatternMasker.java
@@ -189,7 +189,11 @@ public final class MultilinePatternMasker implements Masker<String> {
                 throw new IllegalArgumentException("Pattern cannot be blank");
             }
 
-            //            defaultMaskerPatterns.add(pattern);
+            if (defaultMaskerPatterns.contains(pattern)) {
+                throw new IllegalArgumentException(
+                        "Duplicate pattern detected: '%s' is already registered.".formatted(pattern));
+            }
+
             customMaskerPatterns.put(pattern, masker);
             return this;
         }

--- a/src/test/java/io/github/ehayik/jmaskify/MultilinePatternMaskerTests.java
+++ b/src/test/java/io/github/ehayik/jmaskify/MultilinePatternMaskerTests.java
@@ -78,7 +78,7 @@ class MultilinePatternMaskerTests {
     void shouldFailsWhenNoPatternAddedToBuilder() {
         assertThatThrownBy(() -> Masker.multilinePattern().apply("Hello World!"))
                 .isInstanceOf(MaskingException.class)
-                .hasMessage("Mask patterns cannot be empty");
+                .hasMessage("At least one mask pattern must be specified. Use withMaskPattern() to add patterns.");
     }
 
     @ParameterizedTest
@@ -89,5 +89,33 @@ class MultilinePatternMaskerTests {
                         Masker.multilinePattern().withMaskPattern(maskPattern).apply("Hello World!"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Mask pattern cannot be blank");
+    }
+
+    @Test
+    void shouldMaskWithConfiguredStrategies() {
+        // Given
+        var text =
+                """
+2023-05-15 INFO User john.doe@example.com logged in
+2023-05-15 INFO Processing payment with card 5431-8923-1203-5467
+2023-05-15 DEBUG Session ID: aX92mLpQ7zB3
+""";
+        var expectedText =
+                """
+2023-05-15 INFO User ******************** logged in
+2023-05-15 INFO Processing payment with card XXXX-XXXX-XXXX-5467
+2023-05-15 DEBUG Session ID: aX92mLpQ7zB3
+""";
+
+        var masker = Masker.multilinePattern()
+                .withMaskPattern("\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b")
+                .withMaskPattern("\\b\\d{4}-\\d{4}-\\d{4}-\\d{4}\\b", Masker.creditCard('X'))
+                .build();
+
+        // When
+        var actualText = masker.apply(text);
+
+        // Then
+        assertThat(actualText).isEqualTo(expectedText);
     }
 }

--- a/src/test/java/io/github/ehayik/jmaskify/MultilinePatternMaskerTests.java
+++ b/src/test/java/io/github/ehayik/jmaskify/MultilinePatternMaskerTests.java
@@ -96,16 +96,17 @@ class MultilinePatternMaskerTests {
         // Given
         var text =
                 """
-2023-05-15 INFO User john.doe@example.com logged in
-2023-05-15 INFO Processing payment with card 5431-8923-1203-5467
-2023-05-15 DEBUG Session ID: aX92mLpQ7zB3
-""";
+				2023-05-15 INFO User john.doe@example.com logged in
+				2023-05-15 INFO Processing payment with card 5431-8923-1203-5467
+				2023-05-15 DEBUG Session ID: aX92mLpQ7zB3
+				""";
+
         var expectedText =
                 """
-2023-05-15 INFO User ******************** logged in
-2023-05-15 INFO Processing payment with card XXXX-XXXX-XXXX-5467
-2023-05-15 DEBUG Session ID: aX92mLpQ7zB3
-""";
+				2023-05-15 INFO User ******************** logged in
+				2023-05-15 INFO Processing payment with card XXXX-XXXX-XXXX-5467
+				2023-05-15 DEBUG Session ID: aX92mLpQ7zB3
+				""";
 
         var masker = Masker.multilinePattern()
                 .withMaskPattern("\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b")

--- a/src/test/java/io/github/ehayik/jmaskify/MultilinePatternMaskerTests.java
+++ b/src/test/java/io/github/ehayik/jmaskify/MultilinePatternMaskerTests.java
@@ -77,7 +77,7 @@ class MultilinePatternMaskerTests {
     @Test
     void shouldFailsWhenNoPatternAddedToBuilder() {
         assertThatThrownBy(() -> Masker.multilinePattern().apply("Hello World!"))
-                .isInstanceOf(MaskingException.class)
+                .isInstanceOf(IllegalStateException.class)
                 .hasMessage("At least one mask pattern must be specified. Use withMaskPattern() to add patterns.");
     }
 

--- a/src/test/java/io/github/ehayik/jmaskify/MultilinePatternMaskerTests.java
+++ b/src/test/java/io/github/ehayik/jmaskify/MultilinePatternMaskerTests.java
@@ -75,24 +75,7 @@ class MultilinePatternMaskerTests {
     }
 
     @Test
-    void shouldFailsWhenNoPatternAddedToBuilder() {
-        assertThatThrownBy(() -> Masker.multilinePattern().apply("Hello World!"))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("At least one mask pattern must be specified. Use withMaskPattern() to add patterns.");
-    }
-
-    @ParameterizedTest
-    @NullAndEmptySource
-    @ValueSource(strings = " ")
-    void shouldFailsWhenMaskPatternIsBlank(String maskPattern) {
-        assertThatThrownBy(() ->
-                        Masker.multilinePattern().withMaskPattern(maskPattern).apply("Hello World!"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Mask pattern cannot be blank");
-    }
-
-    @Test
-    void shouldMaskWithConfiguredStrategies() {
+    void shouldMaskWhenCustomAndDefaultMaskingStrategiesConfigured() {
         // Given
         var text =
                 """
@@ -123,5 +106,79 @@ class MultilinePatternMaskerTests {
 
         // Then
         assertThat(actualText).isEqualTo(expectedText);
+    }
+
+    @Test
+    void shouldMaskWhenCustomMaskingStrategiesConfigured() {
+        // Given
+        var text =
+                """
+				2023-05-15 INFO User john.doe@example.com logged in
+				2023-05-15 INFO Processing payment with card 5431-8923-1203-5467
+				2023-05-15 DEBUG Session ID: aX92mLpQ7zB3
+				2023-05-15 INFO IP Address: 192.168.1.1
+				""";
+
+        var expectedText =
+                """
+				2023-05-15 INFO User john.doe@example.com logged in
+				2023-05-15 INFO Processing payment with card XXXX-XXXX-XXXX-5467
+				2023-05-15 DEBUG Session ID: aX92mLpQ7zB3
+				2023-05-15 INFO IP Address: ■■■.■■■.■.■
+				""";
+
+        var masker = Masker.multilinePattern()
+                .withMaskPattern(
+                        "(\\d+\\.\\d+\\.\\d+\\.\\d+)",
+                        Masker.fixedLength().withSubstitution('■').ignore('.'))
+                .withMaskPattern("\\b\\d{4}-\\d{4}-\\d{4}-\\d{4}\\b", Masker.creditCard('X'))
+                .build();
+
+        // When
+        var actualText = masker.apply(text);
+
+        // Then
+        assertThat(actualText).isEqualTo(expectedText);
+    }
+
+    @Test
+    void shouldFailsWhenNoPatternSpecified() {
+        assertThatThrownBy(() -> Masker.multilinePattern().apply("Hello World!"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("At least one masking pattern must be specified. Use withMaskPattern() to add patterns.");
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = " ")
+    void shouldFailsWhenMaskPatternIsBlank(String maskPattern) {
+        assertThatThrownBy(() ->
+                Masker.multilinePattern().withMaskPattern(maskPattern).apply("Hello World!"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Mask pattern cannot be blank");
+    }
+
+    @Test
+    void shouldFailsWhenDuplicateDefaultMaskingPatternSpecified() {
+        // Given
+        var masker = Masker.multilinePattern()
+                .withMaskPattern("(\\d+\\.\\d+\\.\\d+\\.\\d+)", Masker.fixedLength());
+
+        // When - Then
+        assertThatThrownBy(() -> masker.withMaskPattern("(\\d+\\.\\d+\\.\\d+\\.\\d+)"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Duplicate pattern detected: '(\\d+\\.\\d+\\.\\d+\\.\\d+)' is already registered.");
+    }
+
+    @Test
+    void shouldFailsWhenCustomMaskingPatternSpecified() {
+        // Given
+        var masker = Masker.multilinePattern()
+                .withMaskPattern("(\\d+\\.\\d+\\.\\d+\\.\\d+)");
+
+        // When - Then
+        assertThatThrownBy(() -> masker.withMaskPattern("(\\d+\\.\\d+\\.\\d+\\.\\d+)", Masker.fixedLength()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Duplicate pattern detected: '(\\d+\\.\\d+\\.\\d+\\.\\d+)' is already registered.");
     }
 }

--- a/src/test/java/io/github/ehayik/jmaskify/MultilinePatternMaskerTests.java
+++ b/src/test/java/io/github/ehayik/jmaskify/MultilinePatternMaskerTests.java
@@ -99,6 +99,7 @@ class MultilinePatternMaskerTests {
 				2023-05-15 INFO User john.doe@example.com logged in
 				2023-05-15 INFO Processing payment with card 5431-8923-1203-5467
 				2023-05-15 DEBUG Session ID: aX92mLpQ7zB3
+				2023-05-15 INFO IP Address: 192.168.1.1
 				""";
 
         var expectedText =
@@ -106,10 +107,14 @@ class MultilinePatternMaskerTests {
 				2023-05-15 INFO User ******************** logged in
 				2023-05-15 INFO Processing payment with card XXXX-XXXX-XXXX-5467
 				2023-05-15 DEBUG Session ID: aX92mLpQ7zB3
+				2023-05-15 INFO IP Address: ■■■.■■■.■.■
 				""";
 
         var masker = Masker.multilinePattern()
                 .withMaskPattern("\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b")
+                .withMaskPattern(
+                        "(\\d+\\.\\d+\\.\\d+\\.\\d+)",
+                        Masker.fixedLength().withSubstitution('■').ignore('.'))
                 .withMaskPattern("\\b\\d{4}-\\d{4}-\\d{4}-\\d{4}\\b", Masker.creditCard('X'))
                 .build();
 


### PR DESCRIPTION
To add support for custom masking strategies to the multiline text masker, enabling developers to define and apply specific masking patterns and strategies.

```java
var logContent = """
  2023-05-15 INFO User john.doe@example.com logged in
  2023-05-15 INFO Processing payment with card 5431-8923-1203-5467
  2023-05-15 DEBUG Session ID: aX92mLpQ7zB3
""";

var masker = Masker.multilinePattern()
    .withPattern("\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b", Masker.fixedLength(8))
    .withPattern("\\b\\d{4}-\\d{4}-\\d{4}-\\d{4}\\b", Masker.creditCard('X'))
    .build();

var maskedLog = masker.apply(logContent);
// Result:
// 2023-05-15 INFO User ******** logged in
// 2023-05-15 INFO Processing payment with card XXXX-XXXX-XXXX-5467
// 2023-05-15 DEBUG Session ID: aX92mLpQ7zB3
```