### PR TITLE
docs(guidelines): add AI agent guide and update architecture and PR guidelines

### DIFF
--- a/.junie/guidelines/AGENTS.md
+++ b/.junie/guidelines/AGENTS.md
@@ -1,0 +1,372 @@
+# JMaskify – AI Agent’s Guide
+
+This document outlines coding standards, contribution practices, and development workflows for the JMaskify project.
+
+## Table of Contents
+
+- [Quick-start checklist](#quick-start-checklist)
+- [Feature Checklist](#feature-checklist)
+- [Code Style & Quality](#code-style--quality)
+- [Testing Guidelines](#testing-guidelines)
+- [Git Workflow](#git-workflow)
+- [Documentation](#documentation)
+- [Security Best Practices](#security-best-practices)
+- [Common Development Tasks](#common-development-tasks)
+- [Code Review Checklist](#code-review-checklist)
+- [Constraints](#constraints)
+
+## Quick-start checklist
+
+- [ ] Read this file and `README.md` before acting to:
+  - Familiarize yourself with the library's core concepts and use cases
+  - Explore the available maskers and their use cases
+  - Understand the security considerations and guidelines for consumers
+
+## Feature Checklist
+
+- [ ] Simple, clean, concise code
+- [ ] Follows the [java guidelines](java-guidelines.md)
+- [ ] Follows the [architecture guidelines](architecture-guidelines.md)
+- [ ] Error handling + logging
+- [ ] Tests added and passing
+- [ ] Documentation updated (`README.md`) 
+- [ ] Code formatted (`mvn spotless:apply`)
+- [ ] No warnings
+- [ ] `CHANGELOG.md` updated for user-facing changes
+
+**If something is unclear, ask before making assumptions.**
+
+## Code Style & Quality
+
+### Formatting Standards
+
+The project uses **Spotless** with **Palantir Java Format** for code formatting:
+
+- **Indentation**: Tabs (four spaces per tab)
+- **Line Endings**: Unix-style (LF)
+- **Trailing Whitespace**: Removed
+- **File Ending**: Must end with newline
+- **Import Organization**: Automatic via Spotless
+
+### Format Code Automatically
+
+```bash  
+# Format all Java and POM files  
+mvn spotless:apply  
+  
+# Check formatting without applying  
+mvn spotless:check  
+```  
+
+### Null Safety & Error Detection
+
+The project uses **ErrorProne** with **NullAway** for compile-time static analysis:
+
+- All production code is considered non-nullable by default. Use `@Nullable` to mark nullable types explicitly (via JSpecify).
+- Null checks are enforced at compile time
+- NullAway errors are treated as compilation failures
+- Test code is excluded from null-checking requirements
+
+### Code Quality Tools
+
+- **SonarCloud**: Continuous quality monitoring
+    - See: [SonarCloud Dashboard](https://sonarcloud.io/summary/new_code?id=ehayik_jmaskify)
+- **JaCoCo**: Code coverage reporting
+- **Error Prone**: Static bug detection
+
+### Annotations
+
+Use JSpecify annotations for null-safety:
+
+```java  
+import org.jspecify.annotations.Nullable;  
+ 
+// Nullable parameter and return type  
+public @Nullable String process(@Nullable String data) {  
+    return null;
+}  
+```  
+
+## Testing Guidelines
+
+### Testing Framework
+
+- **Framework**: JUnit 5 (Jupiter)
+- **Assertions**: AssertJ for fluent assertions
+- **Mocking**: Mockito for test doubles
+- **Data Generation**: DataFaker for realistic test data
+- **JSON Testing**: JSONAssert for JSON comparisons
+
+### Test Organization
+
+Tests should be organized as follows:
+
+- **Location**: `src/test/java/io/github/ehayik/jmaskify/`
+- **Naming**: `*Tests.java` (e.g., `CreditCardMaskerTests.java`)
+- **Structure**: One test class per masker type
+- **Scope**: Cover happy paths, edge cases, and error scenarios
+
+### Writing Effective Tests
+
+1. **Use Descriptive Names**: Test method names should clearly describe what is being tested
+   
+```java  
+   void shouldMaskCreditCardPreservingLastFourDigits() {}
+   void shouldThrowExceptionForInvalidJson() {}  
+   void shouldHandleNullInputGracefully() {} 
+ ```  
+
+2. **Follow GWT Pattern**: Given, When, Then
+
+```java
+@Test  
+   void shouldMaskEmail() {  
+       // Given
+       var email = "john.doe@example.com";       
+       var masker = Masker.fixedLength();  
+       
+       // When
+       var result = masker.apply(email);  
+       
+       // Then  
+       assertThat(result).isEqualTo("*".repeat(email.length()));  
+   }
+```
+
+3. **Test Coverage Requirements**
+  - Aim for >80% code coverage
+  - Cover boundary conditions and edge cases
+  - Test error handling and exceptions
+
+4. **Use Parameterized Tests**: For testing multiple scenarios
+   
+```java  
+   @ParameterizedTest  
+   @ValueSource(strings = { "test1", "test2", "test3" })  
+   void shouldMaskVariousInputs(String input) {  
+       // Test implementation  
+   }  
+```  
+
+## Git Workflow
+
+### Branch Naming Convention
+
+- **Features**: `feat/description-of-feature`
+- **Bug Fixes**: `fix/description-of-bug`
+- **Refactorings**: `ref/fixed-length-masker`
+- **Documentation**: `docs/description-of-docs`
+
+### Commit Message Format
+
+Follow the conventional commit format:
+
+```  
+<type>(<scope>): <subject>  
+  
+<body>  
+  
+<footer>  
+```  
+
+**Types**: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+
+**Example**:
+
+```  
+feat(json-masker): add support for nested array masking  
+  
+Implement recursive masking for nested arrays in JSON structures.  
+This allows users to mask sensitive data at multiple levels of nesting.  
+  
+Fixes #42  
+```  
+
+#### Handling breaking changes
+
+- Appends a `!` after the type/scope
+- Or use `BREAKING CHANGE: <description>` footer
+- If included in the type/scope prefix, breaking changes MUST be indicated by a `!` immediately before the `:`. 
+- If `!` is used, BREAKING CHANGE: MAY be omitted from the footer section, and the commit description SHALL be used to describe the breaking change.
+
+**Examples**:
+
+- Commit message with `!` to draw attention to breaking change
+
+```
+feat!: send an email to the customer when a product is shipped
+```
+
+- Commit message with scope and `!` to draw attention to breaking change
+
+```
+feat(api)!: send an email to the customer when a product is shipped
+```
+
+- Commit message with description and breaking change footer
+
+```
+feat: allow provided config object to extend other configs
+
+BREAKING CHANGE: `extends` key in config file is now used for extending other config files
+```
+
+### Pull Request Process
+
+1. **Read [Pull Request Description Guidelines](pull-request-description-guidelines.md) before creating a PR**, to
+   ensure the PR title and description adhere to the project's guidelines
+
+2. **Create a branch from the `master` branch**
+
+```bash  
+git checkout -b feat/my-feature 
+```
+
+3. **Make Changes & Commit**
+
+```bash  
+   git add .   
+   git commit -m "feat: add new masking strategy" 
+```  
+
+4. **Push to Repository**
+
+```bash  
+   git push origin feat/my-feature  
+```  
+
+5. **Open a Pull Request to the `master` branch on GitHub**
+
+```bash  
+gh pr create --base "master" --head "feat/my-feature" --title "<What>" --body "## Why <Why> ## How <How>  ## Acceptance Criteria <Acceptance Criteria>"
+```
+
+6. **Address Review Comments**
+    - Keep the conversation respectful and collaborative
+    - Respond to all feedback before merging
+    - Update the PR with new commits
+
+7. **Merge Strategy**
+    - Use "Squash and merge" for small feature branches
+    - Use "Create a merge commit" for larger changes
+    - Ensure the CI/CD pipeline passes
+
+## Documentation
+
+### Code Documentation
+
+1. **Javadoc Comments**
+    - Document all public classes and methods
+    - Include `@param`, `@return`, and `@throws` tags
+    - Provide usage examples in Javadoc where helpful
+    - Use `@Deprecated(forRemoval = true, since = "<version")` annotation for deprecated public classes, constructors, and methods
+    - Write clear and concise descriptions
+
+2. **Implementation Notes**
+    - Use `@since` tags to document API changes
+    - Use `@deprecated` tags for deprecated APIs when appropriate
+    - Use `@inheritDoc` to inherit Javadoc from superclasses and interfaces when appropriate
+    - Use `@apiNote` tags to document API usage and behavior where helpful
+    - Use `@implNote` tags to document implementation details where helpful
+    - Use `@implSpec` tags for specification (default implementation) details where helpful
+    - Add inline comments for complex logic only
+    - Avoid redundant or excessive implementation notes and inline comments
+
+3. **Example Javadoc**
+
+```java
+/**
+ * Picks the winners from the specified set of players.
+ * <p>
+ * The returned list defines the order of the winners, where the first
+ * prize goes to the player at position 0. The list will not be null but
+ * can be empty.
+ *
+ * @deprecated Use {@link #pickWinners(Stream)} instead.
+ * @apiNote This method was added after the interface was released in
+ *          version 1.0. It is defined as a default method for compatibility
+ *          reasons.
+ * @implSpec The default implementation will consider each player a winner
+ *           and return them in an unspecified order.
+ * @implNote This implementation has a linear runtime and does not filter out
+ *           null players.
+ * @throws NullPointerException if the specified set of players is null          
+ * @param players
+ *            the players from which the winners will be selected
+ * @return the (ordered) list of the players who won; the list will not
+ *         contain duplicates
+ * @since 1.1
+ */
+@Deprecated(forRemoval = true, since = "1.2")
+default List<String> pickWinners(Set<String> players) {
+	return new ArrayList<>(players);
+}
+```
+
+### README Updates
+
+Update `README.md` when:
+- Adding new masking strategies
+    - Changing public API signatures
+    - Adding new features or examples
+    - Fixing documentation errors
+
+### CHANGELOG
+
+Maintain a `CHANGELOG.md` documenting:
+- New features (under "Added")
+- Bug fixes (under "Fixed")
+- Breaking changes (under "Changed")
+- Deprecations (under "Deprecated")
+
+## Security Best Practices
+
+- **Input Validation**: Always validate and sanitize user input
+- **Null Safety**: Consider all types non-nullable by default. Use `@Nullable` to mark nullable types explicitly.
+- **Error Handling**: Provide meaningful error messages without exposing sensitive data
+- **Dependencies**: Keep dependencies up to date and monitor for vulnerabilities
+
+## Common Development Tasks
+
+### Adding a New Masking Strategy
+
+1. Create a branch: `git checkout -b feat/masker-name`
+2. Create a new class implementing the `Masker<String>` interface (or another relevant input type)
+3. Update the `permits` list in the `Masker` sealed interface
+4. Implement the `apply(@Nullable String input)` method
+5. Provide a static factory method in the `Masker` interface for easy access
+6. Add unit tests in `src/test/java`
+7. Add/Update Javadoc accordingly
+8. Update documentation in `README.md`
+9. Update `CHANGELOG.md`
+10. Create a pull request with the new feature
+
+### Fixing a Bug
+
+1. Create a branch: `git checkout -b fix/bug-description`
+2. Add a failing test that reproduces the bug
+3. Implement the fix
+4. Ensure all tests pass
+5. Update `CHANGELOG.md`
+6. Create a pull request with the fix
+
+## Code Review Checklist
+
+When reviewing code, verify:
+
+- ✅ Tests are comprehensive and meaningful
+- ✅ Code follows project style guidelines
+- ✅ Null-safety annotations are correctly applied
+- ✅ Error handling is appropriate
+- ✅ Documentation is accurate and complete
+- ✅ No security vulnerabilities
+- ✅ Performance is acceptable
+- ✅ Changes are backward-compatible (unless breaking change)
+
+## Constraints
+
+### MUST NOT DO
+
+- Bump major versions of core dependencies without a dedicated PR and discussion
+- Publish new versions to Maven Central
+- Merge a pull request without proper review and approval

--- a/.junie/guidelines/AGENTS.md
+++ b/.junie/guidelines/AGENTS.md
@@ -337,9 +337,9 @@ default List<String> pickWinners(Set<String> players) {
 
 Update `README.md` when:
 - Adding new masking strategies
-    - Changing public API signatures
-    - Adding new features or examples
-    - Fixing documentation errors
+- Changing public API signatures
+- Adding new features or examples
+- Fixing documentation errors
 
 ### CHANGELOG
 

--- a/.junie/guidelines/AGENTS.md
+++ b/.junie/guidelines/AGENTS.md
@@ -224,21 +224,51 @@ git checkout -b feat/my-feature
 
 3. **Make Changes & Commit**
 
+Follow the [Commit Message Format](#commit-message-format) for all commits.
+
 ```bash  
-   git add .   
-   git commit -m "feat: add new masking strategy" 
+git add .   
+git commit -m "feat: add new masking strategy" 
 ```  
 
 4. **Push to Repository**
 
 ```bash  
-   git push origin feat/my-feature  
+git push origin feat/my-feature  
 ```  
 
-5. **Open a Pull Request to the `master` branch on GitHub**
+5. **Open a Pull Request**
 
-```bash  
-gh pr create --base "master" --head "feat/my-feature" --title "<What>" --body "## Why <Why> ## How <How>  ## Acceptance Criteria <Acceptance Criteria>"
+Create a Pull Request to the `master` branch on GitHub. It is recommended to use a temporary file for the PR body to handle multi-line content correctly.
+
+```bash
+# Create a temporary file with the PR body
+cat <<EOF > pr_body.md
+### What
+<Description of the changes>
+
+### Why
+<Justification for the changes>
+
+### How
+<Implementation details>
+
+### Acceptance Criteria
+- [ ] Task 1
+- [ ] Task 2
+EOF
+
+# Create the pull request
+gh pr create --base master --head feat/my-feature --title "feat: add new masking strategy" --body-file pr_body.md
+
+# Clean up
+rm pr_body.md
+```
+
+Alternatively, use the `--fill` flag to automatically use the commit message:
+
+```bash
+gh pr create --base master --head feat/my-feature --fill
 ```
 
 6. **Address Review Comments**
@@ -339,7 +369,7 @@ Maintain a `CHANGELOG.md` documenting:
 7. Add/Update Javadoc accordingly
 8. Update documentation in `README.md`
 9. Update `CHANGELOG.md`
-10. Create a pull request with the new feature
+10. Create a Pull Request with the new feature
 
 ### Fixing a Bug
 
@@ -348,7 +378,7 @@ Maintain a `CHANGELOG.md` documenting:
 3. Implement the fix
 4. Ensure all tests pass
 5. Update `CHANGELOG.md`
-6. Create a pull request with the fix
+6. Create a Pull Request with the fix
 
 ## Code Review Checklist
 

--- a/.junie/guidelines/architecture-guidelines.md
+++ b/.junie/guidelines/architecture-guidelines.md
@@ -1,0 +1,68 @@
+# JMaskify Architecture Guidelines
+
+These guidelines describe the architectural principles, core components, and design patterns used in the JMaskify project to ensure consistency, extensibility, and maintainability.
+
+## Table of Contents
+
+- [1. Architectural Principles](#1-architectural-principles)
+- [2. Core Components](#2-core-components)
+- [3. Design Patterns](#3-design-patterns)
+- [4. Extensibility Guidelines](#4-extensibility-guidelines)
+- [5. Security Considerations](#5-security-considerations)
+
+## 1. Architectural Principles
+
+**The library is built on principles of simplicity, immutability, and functional programming.**
+
+- **Functional Approach**: The core `Masker<T>` interface extends `java.util.function.Function<T, String>`. Masking operations are treated as transformations from an input type to a masked string representation.
+- **Fluent API**: Object creation and configuration are handled through a fluent API, primarily using the Builder pattern, to provide an intuitive and readable interface for users.
+- **Immutability**: Once configured and built, `Masker` instances should be immutable and thread-safe to ensure predictable behavior in concurrent environments.
+- **Minimal Dependencies**: The library aims to keep its dependency footprint small, relying only on essential libraries like Jackson for JSON and SLF4J for logging.
+
+## 2. Core Components
+
+**The architecture is centered around a few key abstractions that define how masking is performed.**
+
+- **`Masker<T>`**: The central interface for all masking strategies. It is a `sealed interface` to control its hierarchy and ensure that all core implementations are known.
+- **Implementations**:
+    - `FixedLengthMasker`: Basic string obfuscation with fixed-length output.
+    - `JsonMasker`: Specialized masker for JSON content using streaming API (Jackson) for efficiency.
+    - `MultilinePatternMasker`: Regex-based masking for unstructured multiline text.
+    - `Base64Masker`: Simple encoding-based masking.
+    - `CreditCardMasker`: Specialized masking for financial data.
+- **`MaskerBuilder<T, R>`**: A generic interface for builders that construct `Masker` instances. It ensures consistency across different builder implementations.
+
+## 3. Design Patterns
+
+**Several design patterns are employed to provide flexibility and ease of use.**
+
+- **Strategy Pattern**: Different masking techniques are implemented as separate classes conforming to the `Masker` interface, allowing users to swap or combine strategies easily.
+- **Builder Pattern**: Complex object construction (especially for `JsonMasker` and `MultilinePatternMasker`) is managed by inner `Builder` classes to handle many configuration options cleanly.
+- **Static Factory Methods**: The `Masker` interface provides static methods (e.g., `Masker.json()`, `Masker.fixedLength()`) as the primary entry points for creating maskers, hiding implementation details.
+- **Decorator / Function Composition**: Since `Masker` extends `Function`, maskers can be composed using `andThen()` to apply multiple masking layers in sequence.
+
+### Example: Masker Composition
+- Maskers can be chained: `jsonMasker.andThen(multilineMasker).apply(input)`.
+
+## 4. Extensibility Guidelines
+
+**Adding new masking capabilities should follow the established patterns to maintain architectural integrity.**
+
+- **New Masking Strategies**:
+    - Implement the `Masker<String>` interface (or another relevant input type).
+    - If the implementation is a core part of the library, update the `permits` list in the `Masker` sealed interface.
+    - Provide a static factory method in the `Masker` interface for easy access.
+- **Custom Masking**:
+    - For one-off or user-specific masking logic, use `Masker.delegate(Function<S, String> delegate)` instead of creating a new class.
+- **Builders**:
+    - Use the `MaskerBuilder` interface for any new complex masker that requires configuration.
+    - Ensure builders are fluent and provide sensible defaults.
+- **Error Handling**:
+    - Use `MaskingException` for any runtime errors during the masking process to provide a consistent error-handling experience.
+
+## 5. Security Considerations
+
+- **No Logging of Sensitive Data**: Never log unmasked input data, parts of it, or masked data, in library logs. Debug or error logs should only contain metadata and field names.
+- **Input Validation**: While the library handles common formats (JSON, multiline text), ensure that new masking strategies validate inputs to prevent potential injection or denial-of-service (DoS) through overly complex regex patterns (Catastrophic Backtracking).
+- **Default Masking**: When in doubt, default to irreversible masking strategies. Reversible strategies must be clearly documented as such.
+- **Dependency Management**: Regularly audit and update dependencies (especially Jackson) to mitigate vulnerabilities in third-party libraries used for data processing.

--- a/.junie/guidelines/java-guidelines.md
+++ b/.junie/guidelines/java-guidelines.md
@@ -5,15 +5,14 @@ These are the general guidelines for writing Java code.
 ## Table of Contents
 
 - [1. Naming Conventions](#1-naming-conventions)
-- [2. Code Layout](#2-code-layout)
-- [3. Best Practices for Classes, Interfaces, and Enums](#3-best-practices-for-classes-interfaces-and-enums)
-- [4. Exception Handling](#4-exception-handling)
-- [5. Concurrency](#5-concurrency)
-- [6. Use of `Optional`](#6-use-of-optional)
-- [7. Stream API Best Practices](#7-stream-api-best-practices)
-- [8. Collections](#8-collections)
-- [9. Date and Time](#9-date-and-time)
-- [10. Strings](#10-strings)
+- [2. Best Practices for Classes, Interfaces, and Enums](#2-best-practices-for-classes-interfaces-and-enums)
+- [3. Exception Handling](#3-exception-handling)
+- [4. Concurrency](#4-concurrency)
+- [5. Use of `Optional`](#5-use-of-optional)
+- [6. Stream API Best Practices](#6-stream-api-best-practices)
+- [7. Collections](#7-collections)
+- [8. Date and Time](#8-date-and-time)
+- [9. Strings](#9-strings)
 
 ## 1. Naming Conventions
 
@@ -25,43 +24,36 @@ Follow the Java naming conventions.
 - Variable names should be in `camelCase` and should be short and meaningful. Avoid single-letter variable names except for loop counters.
 - Constant names should be in `UPPER_SNAKE_CASE`.
 
-## 2. Code Layout
-
-- Use four spaces for indentation. Do not use tabs.
-- Consistent indentation is crucial for readability. Using spaces instead of tabs ensures that the code looks the same on all systems.
-- Keep lines of code under 120 characters.
-- When wrapping lines, break after a comma or an operator. Indent the new line with eight spaces.
-
-## 3. Best Practices for Classes, Interfaces, and Enums
+## 2. Best Practices for Classes, Interfaces, and Enums
 
 - Prefer using Java records for storing data holder classes.
 - Prefer immutable classes whenever possible.
 - Program to interfaces, not implementations.
 - Use enums instead of string constants or integer constants.
 
-## 4. Exception Handling
+## 3. Exception Handling
 
 - Catch specific exceptions instead of `Exception`, `RuntimeException` or `Throwable`.
     - Catching `Exception`, `RuntimeException` or `Throwable` is acceptable only in narrow, well-justified places (top-level handlers, framework boundaries, or when you must guarantee cleanup/logging).
       You should treat such catches as last-resort, log/record full context, and rethrow or terminate appropriately.
 - Never ignore exceptions. If you catch an exception, either handle it or rethrow it.
 
-## 5. Concurrency
+## 4. Concurrency
 
 - Prefer the high-level concurrency utilities in the `java.util.concurrent` package over low-level primitives like `wait()` and `notify()`.
 - Use `volatile` only for simple atomic operations. For more complex operations, use `java.util.concurrent.atomic` or locks.
 
-## 6. Use of `Optional`
+## 5. Use of `Optional`
 
 - Use `Optional` for return types when a method might not return a value.
 - Do not use `Optional` for class fields or method parameters.
 
-## 7. Stream API Best Practices
+## 6. Stream API Best Practices
 
 - Avoid side effects in stream operations like `map()` and `filter()`.
 - Prefer method references over lambdas when possible.
 
-## 8. Collections
+## 7. Collections
 
 - Choose the right collection for the job. Use `List` for ordered collections, `Set` for unordered collections with no duplicates, and `Map` for key-value pairs.
 - Use `isEmpty()` to check if a collection is empty.
@@ -69,10 +61,10 @@ Follow the Java naming conventions.
 - Use the diamond operator (`<>`) for generic type inference.
 - Prefer the `for-each` loop for iterating over collections.
 
-## 9. Date and Time
+## 8. Date and Time
 
 - Prefer using the Java 8 Date-Time API (`java.time.*`) over the legacy `java.util.Date`/`java.util.Calendar` APIs.
 
-## 10. Strings
+## 9. Strings
 
 - Use multiline text blocks (`"""`), available since Java 15, for multi-line string literals (e.g., SQL, JSON, XML) instead of concatenation or newline escapes.

--- a/.junie/guidelines/java-guidelines.md
+++ b/.junie/guidelines/java-guidelines.md
@@ -1,0 +1,78 @@
+# Java Guidelines
+
+These are the general guidelines for writing Java code.
+
+## Table of Contents
+
+- [1. Naming Conventions](#1-naming-conventions)
+- [2. Code Layout](#2-code-layout)
+- [3. Best Practices for Classes, Interfaces, and Enums](#3-best-practices-for-classes-interfaces-and-enums)
+- [4. Exception Handling](#4-exception-handling)
+- [5. Concurrency](#5-concurrency)
+- [6. Use of `Optional`](#6-use-of-optional)
+- [7. Stream API Best Practices](#7-stream-api-best-practices)
+- [8. Collections](#8-collections)
+- [9. Date and Time](#9-date-and-time)
+- [10. Strings](#10-strings)
+
+## 1. Naming Conventions
+
+Follow the Java naming conventions.
+
+- Package names should be all lowercase, without underscores or other special characters. They should be short, meaningful, and based on the project's domain.
+- Class and interface names should be in `PascalCase` and should be nouns or noun phrases.
+- Method names should be in `camelCase` and should be verbs or verb phrases.
+- Variable names should be in `camelCase` and should be short and meaningful. Avoid single-letter variable names except for loop counters.
+- Constant names should be in `UPPER_SNAKE_CASE`.
+
+## 2. Code Layout
+
+- Use four spaces for indentation. Do not use tabs.
+- Consistent indentation is crucial for readability. Using spaces instead of tabs ensures that the code looks the same on all systems.
+- Keep lines of code under 120 characters.
+- When wrapping lines, break after a comma or an operator. Indent the new line with eight spaces.
+
+## 3. Best Practices for Classes, Interfaces, and Enums
+
+- Prefer using Java records for storing data holder classes.
+- Prefer immutable classes whenever possible.
+- Program to interfaces, not implementations.
+- Use enums instead of string constants or integer constants.
+
+## 4. Exception Handling
+
+- Catch specific exceptions instead of `Exception`, `RuntimeException` or `Throwable`.
+    - Catching `Exception`, `RuntimeException` or `Throwable` is acceptable only in narrow, well-justified places (top-level handlers, framework boundaries, or when you must guarantee cleanup/logging).
+      You should treat such catches as last-resort, log/record full context, and rethrow or terminate appropriately.
+- Never ignore exceptions. If you catch an exception, either handle it or rethrow it.
+
+## 5. Concurrency
+
+- Prefer the high-level concurrency utilities in the `java.util.concurrent` package over low-level primitives like `wait()` and `notify()`.
+- Use `volatile` only for simple atomic operations. For more complex operations, use `java.util.concurrent.atomic` or locks.
+
+## 6. Use of `Optional`
+
+- Use `Optional` for return types when a method might not return a value.
+- Do not use `Optional` for class fields or method parameters.
+
+## 7. Stream API Best Practices
+
+- Avoid side effects in stream operations like `map()` and `filter()`.
+- Prefer method references over lambdas when possible.
+
+## 8. Collections
+
+- Choose the right collection for the job. Use `List` for ordered collections, `Set` for unordered collections with no duplicates, and `Map` for key-value pairs.
+- Use `isEmpty()` to check if a collection is empty.
+- Methods that return collections should return an empty collection instead of `null`.
+- Use the diamond operator (`<>`) for generic type inference.
+- Prefer the `for-each` loop for iterating over collections.
+
+## 9. Date and Time
+
+- Prefer using the Java 8 Date-Time API (`java.time.*`) over the legacy `java.util.Date`/`java.util.Calendar` APIs.
+
+## 10. Strings
+
+- Use multiline text blocks (`"""`), available since Java 15, for multi-line string literals (e.g., SQL, JSON, XML) instead of concatenation or newline escapes.

--- a/.junie/guidelines/pull-request-description-guidelines.md
+++ b/.junie/guidelines/pull-request-description-guidelines.md
@@ -1,0 +1,78 @@
+# Pull Request Description Guidelines
+
+These are the general guidelines for writing clear and effective pull request descriptions.
+
+## Table of Contents
+
+- [1. What (Headline)](#1-what-headline)
+- [2. Why (Justification)](#2-why-justification)
+- [3. How (Implementation Approach)](#3-how-implementation-approach)
+- [4. Acceptance Criteria](#4-acceptance-criteria)
+- [5. Best Practices](#5-best-practices)
+
+## 1. What (Headline)
+
+The "What" section serves as the **Pull Request title**.
+
+- **Be specific and concise**: Clearly state what needs to be done in a single sentence. Limit the title to around 50 characters if possible.
+- **Use imperative mood**: Write the title as if you are giving a command (e.g., "Fix issue" instead of "Fixed issue").
+- **Use action verbs**: Start with keywords like "Add," "Fix," "Update," "Remove," etc., to indicate the type of change.
+- **Name the affected component/module**: Identify where in the system the change occurs.
+- **Avoid redundancy**: Don't repeat information already clear from context. Specify the bug or feature clearly.
+
+## 2. Why (Justification)
+
+- **Explain the business/technical motivation**: Why is this task necessary?
+- **Describe the problem being solved**: What issue or requirement does this address?
+- **Mention expected benefits**: How will this improve the system or user experience?
+
+## 3. How (Implementation Approach)
+
+- **Outline the implementation strategy**: Break down the solution into logical steps.
+- **List key technical changes**: Identify major components that need modification.
+- **Set boundaries**: Define the scope of work and what is not included if relevant.
+
+## 4. Acceptance Criteria
+
+- **Define clear, testable outcomes**: What must be true for the task to be considered finished?
+- **Include verification steps**: Mention specific tests, manual checks, or edge cases that must be validated.
+- **Use checkboxes**: To allow for easy tracking of progress and completion.
+
+## 5. Best Practices
+
+- **Be concise but complete**: Include all necessary information while avoiding unnecessary details.
+- **Use bullet points**: For clarity in the "How" section.
+- **Include Acceptance Criteria**: Ensure every task has measurable success conditions.
+- **Include context**: That helps readers understand the task's importance.
+- **Consider dependencies**: Mention related tasks or prerequisites.
+
+## Example
+
+```
+### What
+
+Enhance JsonMasker to support masking string values in JSON arrays and nested arrays
+
+### Why
+
+To provide comprehensive masking capabilities for JSON arrays, including mixed-type and nested arrays.
+This enhancement ensures that sensitive string data within arrays is properly masked while preserving non-string values,
+improving data protection across more complex JSON structures.
+
+### How
+
+- Add functionality to detect and mask string values within JSON arrays, including nested arrays
+- Preserve non-string values (numbers, booleans, null) in arrays during masking operations
+- Implement logging for fields that are ignored due to missing or unsupported masking strategies
+- Expand README documentation with examples demonstrating array and nested array masking capabilities
+
+### Acceptance Criteria
+
+- [ ] String values in flat arrays are correctly masked
+- [ ] String values in nested arrays are correctly masked
+- [ ] Mixed-type arrays preserve non-string values while masking strings
+- [ ] Fields with missing or unsupported masking strategies are logged appropriately
+- [ ] README includes clear examples of array and nested array masking use cases
+- [ ] All existing tests continue to pass
+- [ ] New unit tests cover array masking scenarios (flat, nested, and mixed-type arrays)
+```

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Eduardo Eljaiek Rodriguez
+Copyright (c) 2025 Eduardo Eljaiek Rodriguez
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the "Software"), to deal, in the Software without restriction, including without limitation the


### PR DESCRIPTION
### What

Add AI agent guide and update architecture, Java, and PR description guidelines to improve project documentation and consistency.

### Why

To provide a comprehensive set of guidelines for both human and AI contributors, ensuring consistent code style, architecture, and documentation across the JMaskify project.

### How

- Add a new `AGENTS.md` guide specifically for AI agents.
- Add a new `java-guidelines.md` document outlining Java coding standards.
- Update `architecture-guidelines.md` to include security considerations.
- Update `pull-request-description-guidelines.md` with better structure and more relevant examples.
- Update `LICENSE.md` to 2025.

### Acceptance Criteria

- [x] All new documentation files are correctly formatted and structured.
- [x] Guidelines align with project goals and existing code structure.