### PR TITLE
fix: address CVE-2025-48924 by updating commons-lang3 to 3.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix split behavior for dashed credit card numbers
+- Address CVE-2025-48924 by updating `commons-lang3` to version `3.20.0`
 
 ### Changed
 - Introduce a new `MaskerBuilder` interface to standardize masker builder functionality

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <jackson.version>2.18.0</jackson.version>
         <junit.version>5.11.3</junit.version>
         <lombok.version>1.18.34</lombok.version>
-        <commons-lang3.version>3.17.0</commons-lang3.version>
+        <commons-lang3.version>3.20.0</commons-lang3.version>
         <commons-codec.version>1.17.1</commons-codec.version>
         <jsonassert.version>1.5.3</jsonassert.version>
         <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>


### PR DESCRIPTION
### What
Update `commons-lang3` to version 3.20.0 to address CVE-2025-48924.

### Why
To mitigate a security vulnerability detected in the existing version of `commons-lang3`.

### How
- Update `commons-lang3.version` property in `pom.xml`.
- Update `CHANGELOG.md` with the security fix.

### Acceptance Criteria
- [x] Dependency version updated.
- [x] CHANGELOG reflects the change.
- [x] All unit tests pass.
