### PR TITLE
chore(release): bump version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.0] - TBD
+## [1.1.0] - 2026-04-19
 
 ### Fixed
 - Fix split behavior for dashed credit card numbers

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ JMaskify is available on Maven Central. Add the dependency to your project:
 <dependency>
     <groupId>io.github.ehayik</groupId>
     <artifactId>jmaskify</artifactId>
-    <version>1.0.1</version>
+    <version>1.1.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.github.ehayik</groupId>
     <artifactId>jmaskify</artifactId>
-    <version>1.0.1</version>
+    <version>1.1.0</version>
 
     <name>JMaskify</name>
     <description>JMaskify is an open-source Java library designed to safeguard sensitive data with versatile and


### PR DESCRIPTION
### What
Bump project version to 1.1.0 and update documentation.

### Why
To prepare for the 1.1.0 release, ensuring that the version in `pom.xml`, `CHANGELOG.md`, and `README.md` are all consistent and reflect the current release state.

### How
- Updated `version` in `pom.xml` to `1.1.0`.
- Updated `CHANGELOG.md` to replace `TBD` with the release date (`2026-04-19`).
- Updated `README.md` installation example to use version `1.1.0`.

### Acceptance Criteria
- [x] Version in `pom.xml` is `1.1.0`.
- [x] `CHANGELOG.md` has the correct release date for `1.1.0`.
- [x] `README.md` reflects the new version in the installation example.
- [x] Project builds successfully and code is formatted.
