### PR TITLE
docs(readme): refactor code examples to use var and streamline API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ var maskedEmail = Masker.fixedLength().apply(email);
 For masking fields within JSON objects:
 
 ```java
-String json = """
+var json = """
 {
   "name": "John Doe",
   "age": 30,
@@ -151,7 +151,7 @@ Here are examples of different array masking scenarios:
 When you need to mask an array of sensitive string values, such as credit card numbers:
 
 ```java
-String json = """
+var json = """
 {
     "name": "John Doe",
     "creditCards": [
@@ -161,11 +161,9 @@ String json = """
 }
 """;
 
-var masker = Masker.json()
-    .withProperty("creditCards", Masker.creditCard('X'))
-    .build();
-
-var maskedJson = masker.apply(json);
+var maskedJson = Masker.json()
+        .withProperty("creditCards", Masker.creditCard('X'))
+        .apply(json);
 
 /* Result:
 {
@@ -183,7 +181,7 @@ var maskedJson = masker.apply(json);
 JMaskify can handle arrays containing a mix of different value types, masking only the string values:
 
 ```java
-String json = """
+var json = """
 {
     "name": "John Doe",
     "mixedArray": [
@@ -197,11 +195,9 @@ String json = """
 }
 """;
 
-var masker = Masker.json()
-    .withProperty("mixedArray", Masker.fixedLength())
-    .build();
-
-var maskedJson = masker.apply(json);
+var maskedJson = Masker.json()
+        .withProperty("mixedArray", Masker.fixedLength())
+        .apply(json);
 
 /* Result:
 {
@@ -223,7 +219,7 @@ var maskedJson = masker.apply(json);
 JMaskify handles nested arrays with specific masking behavior:
 
 ```java
-String json = """
+var json = """
 {
     "name": "John Doe",
     "nestedArrays": [
@@ -234,11 +230,9 @@ String json = """
 }
 """;
 
-var masker = Masker.json()
+var maskedJson = Masker.json()
     .withProperty("nestedArrays", Masker.fixedLength())
-    .build();
-
-var maskedJson = masker.apply(json);
+    .apply(json);
 
 /* Result:
 {
@@ -260,7 +254,7 @@ var maskedJson = masker.apply(json);
 When working with log files or other text that spans multiple lines, you can use multiline text masking to identify and mask patterns:
 
 ```java
-String logContent = """
+var logContent = """
           2023-05-15 INFO User john.doe@example.com logged in
           2023-05-15 INFO IP Address: 192.168.1.1
         """;
@@ -291,15 +285,11 @@ JMaskify provides several ways to customize the behavior of its core maskers.
 The `FixedLengthMasker` can be configured to preserve parts of the input, ignore specific characters, or use a custom substitution character.
 
 ```java
-import io.github.ehayik.jmaskify.Masker;
-
 // Configure a masker with prefix/suffix preservation and custom substitution
-var masker = Masker.fixedLength()
-        .withFixedLength(10)          // Resulting masked part will be 10 characters
+var masker = Masker.fixedLength(10)   // Resulting masked part will be 10 characters
         .withSubstitution('#')        // Use '#' instead of '*'
         .preservePrefix(2)            // Keep first 2 characters
-        .preserveSuffix(2)            // Keep last 2 characters
-        .build();
+        .preserveSuffix(2);            // Keep last 2 characters
 
 var result = masker.apply("1234567890123");
 // Result: "12##########23" (prefix "12" + 10 '#' + suffix "23")


### PR DESCRIPTION
### Why

To modernize the documentation and showcase the most efficient way to use the JMaskify library, taking advantage of the \`MaskerBuilder\` interface and Java 17+ features.

### How

- Replace explicit \`String\` declarations with \`var\` in JSON and log content examples
- Streamline masker application by calling \`.apply()\` directly on the builder instances where appropriate
- Simplify \`FixedLengthMasker\` configuration by using the \`Masker.fixedLength(int)\` factory method
- Remove redundant imports in examples

### Acceptance Criteria

- [x] All code examples are technically accurate
- [x] Examples follow the library's fluent API design
- [x] No functional changes to the codebase
- [x] README remains well-formatted
