### PR TITLE
docs(agents): indicate files formatted by Spotless

### DIFF
--- a/.junie/AGENTS.md
+++ b/.junie/AGENTS.md
@@ -56,7 +56,10 @@ mvn spotless:apply
   
 # Check formatting without applying  
 mvn spotless:check  
-```  
+```
+
+>**NOTE:**
+> Only `.java` and `pom.xml` files are formatted by Spotless.
 
 ### Null Safety & Error Detection
 


### PR DESCRIPTION
### Why
To inform AI agents that only `.java` and `pom.xml` files are subject to automatic formatting, helping them decide when to run `mvn spotless:apply`.

### How
Added a note in the "Format Code Automatically" section of `.junie/AGENTS.md`.

### Acceptance Criteria
- [x] AGENTS.md updated
- [x] PR created following project guidelines