### PR TITLE
docs(agents): improve pull request creation instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ build/
 .DS_Store
 /project-brief.md
 /.flattened-pom.xml
+
+.junie/memory/
+.junie/plans/

--- a/.junie/AGENTS.md
+++ b/.junie/AGENTS.md
@@ -246,7 +246,7 @@ Create a Pull Request to the `master` branch on GitHub. It is recommended to use
 
 ```bash
 # Create a temporary file with the PR body
-cat <<EOF > target/pr_body.md
+cat <<EOF > target/pr_<changes-name>-body.md
 ### What
 <Description of the changes>
 
@@ -266,6 +266,9 @@ gh pr create --base master --head feat/my-feature --title "feat: add new masking
 ```
 
 Alternatively, use the `--fill` flag to automatically use the commit message:
+
+> **NOTE**
+> Do not try to delete the PR body temporary file.
 
 ```bash
 gh pr create --base master --head feat/my-feature --fill


### PR DESCRIPTION
### Why

To prevent file name collisions when AI agents generate temporary PR body files and to ensure that local agent-specific folders (memory and plans) are not tracked by version control.

### How

- Add a note in `AGENTS.md` advising against deleting the temporary PR body file manually.
- Add `.junie/memory/` and `.junie/plans/` to `.gitignore` to keep the repository clean.

### Acceptance Criteria

- [ ] Warning about not deleting the PR body file is added to `AGENTS.md`.
- [ ] `.gitignore` correctly excludes agent-specific memory and plans directories.
